### PR TITLE
Update to Python 3

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,17 +2,5 @@
     "python.linting.pylintEnabled": false,
     "python.linting.pycodestyleEnabled": true,
     "python.linting.enabled": true,
-    "python.linting.pycodestyleArgs": ["--ignore=E501"],
-    "python.testing.unittestEnabled": true,
-    "python.testing.pytestEnabled": false,
-    "python.testing.nosetestsEnabled": false,
-    "python.pythonPath": "C:\\Python27\\python.exe",
-    "python.testing.cwd": "./python",
-    "python.testing.unittestArgs": [
-        "-v",
-        "-s",
-        "./python/GafferDeadlineTest",
-        "-p",
-        "*.py"
-    ]
+    "python.linting.pycodestyleArgs": ["--max-line-length=99"],
 }

--- a/GafferDeadline.code-workspace
+++ b/GafferDeadline.code-workspace
@@ -4,5 +4,7 @@
 			"path": "."
 		}
 	],
-	"settings": {}
+	"settings": {
+		"python.pythonPath": "${env:GAFFER_ROOT}/bin/python.exe"
+	}
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.com/ericmehl/GafferDeadline.svg?branch=master)](https://travis-ci.com/ericmehl/GafferDeadline)
-[![Build status](https://ci.appveyor.com/api/projects/status/yxwvuof88k1ycixa/branch/master?svg=true)](https://ci.appveyor.com/project/Hypothetical/gafferdeadline/branch/master)
 # GafferDeadline #
 Deadline Dispatcher for Gaffer. There are three components - the Gaffer dispatcher, Deadline plugin and Python dependency script called by Deadline to check for task dependencies getting released.
 

--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ GafferDeadline sets the environment variable CPUTHREAD the Deadline Worker's ren
 ## Running Unit Tests ##
 You don't need to run the unit tests for normal use of GafferDeadline, but if you want to make customizations it is recommended that you add unit tests as appropriate and run the existing tests to ensure compatibility.
 
-To run the unit tests, you need to have an installation of Gaffer and have your Python environment setup to point to that installation. The easiest way to do that is to use the included gaffer_env (Linux) and gaffer_env.bat (Windows) files to setup the environment first. Then you can use regular Python unit test runners to run tests.
-
-More specifically:
-1. PATH environment variable needs to include the gaffer/bin, gaffer/lib (on Windows) and gaffer/python directories.
-2. PYTHONPATH environment variable needs to include the gaffer/python directory and the GafferDeadline/python directory.
-3. On Linux the LD_LIBRARY_PATH needs to be set to the gaffer/lib directory.
+To run the unit tests, you need to have an installation of Gaffer.
+- All OS : set the GAFFER_EXTENSION_PATHS environment variable to the directory for GafferDeadline.
+- Linux : set the GAFFER_ROOT environment variable to your Gaffer installation directory. From the GAFFER_ROOT/bin directory, run 
+        ./gaffer test GafferDeadlineTest GafferDeadlineUITest
+- Windows : You don't need to set the GAFFER_ROOT environment variable. From your Gaffer installation "bin" subdirectory, 
+        run gaffer.bat test GafferDeadlineTest GafferDeadlineUITest
 
 There is also a Visual Studio Code environment included that may be helpful.
 

--- a/python/GafferDeadline/DeadlineDispatcher.py
+++ b/python/GafferDeadline/DeadlineDispatcher.py
@@ -65,41 +65,60 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
 
     def _doDispatch(self, root_batch):
         '''
-        _doDispatch is called by Gaffer, the others (prefixed with __) are just helpers for Deadline
+        _doDispatch is called by Gaffer, the others (prefixed with __) are just helpers for
+        Deadline
 
         Note that Gaffer and Deadline use some terms differently
-        Gaffer Batch =~ Deadline Task, which could be multiple frames in a single task. Depending on batch layout
-                        multiple Deadline Tasks may be needed to fullfill a single Gaffer Batch. For example, a Deadline
-                        Task can only handle sequential frames.
-        Gaffer TaskNode =~ Deadline Job. A Gaffer Task can have multiple Deadline Jobs to complete it depending on batch and context layout.
-                            A DeadlineJob is defined by the combination of Gaffer TaskNode and Context.
+        Gaffer Batch =~ Deadline Task, which could be multiple frames in a single task. Depending
+                        on batch layout multiple Deadline Tasks may be needed to fullfill a single
+                        Gaffer Batch. For example, a Deadline Task can only handle sequential
+                        frames.
+        Gaffer TaskNode =~ Deadline Job. A Gaffer Task can have multiple Deadline Jobs to complete
+                            it depending on batch and context layout. A DeadlineJob is defined by
+                            the combination of Gaffer TaskNode and Context.
         Gaffer Job = set of Deadline Jobs (could be considered a Deadline Batch)
-        Use DeadlineJob, DeadlineTask, etc. to denote Deadline terminology and plain Batch, Job, etc. to denote Gaffer terminology.
+        Use DeadlineJob, DeadlineTask, etc. to denote Deadline terminology and plain Batch, Job,
+                            etc. to denote Gaffer terminology.
 
         Batches can have dependencies completely independent of frame numbers. First
-        walk through the batch tree to build up a set of GafferDeadlineJob objects with GafferDeadlineTask objects corresponding
-        to the batches.
+        walk through the batch tree to build up a set of GafferDeadlineJob objects with
+                            GafferDeadlineTask objects corresponding to the batches.
 
-        When all tasks are created, go back through the tree to setup dependencies between tasks. Task dependencies may be different
-        from Batch dependencies because batches may have been split to accommodate Deadline's sequential frame task requirement.
+        When all tasks are created, go back through the tree to setup dependencies between tasks.
+                            Task dependencies may be different
+        from Batch dependencies because batches may have been split to accommodate Deadline's
+                            sequential frame task requirement.
 
-        With dependencies set, start at the leaf nodes of the task tree (no upstream DeadlineJobs) and submit those first. That way
-        the Deadline Job ID can be stored and used by dependent jobs to set their dependencies correctly.
+        With dependencies set, start at the leaf nodes of the task tree (no upstream DeadlineJobs)
+                            and submit those first. That way
+        the Deadline Job ID can be stored and used by dependent jobs to set their dependencies
+                            correctly.
 
-        To be compatible with Deadline's ExtraInfoKeyValue system, dependencies are reformatted at submission as
+        To be compatible with Deadline's ExtraInfoKeyValue system, dependencies are reformatted at
+                            submission as
         task:job_dependency_id=task_dependency_number
         '''
         self._deadline_jobs = []
         IECore.Log.info("Beginning Deadline submission")
         dispatch_data = {}
         dispatch_data["scriptNode"] = root_batch.preTasks()[0].node().scriptNode()
-        dispatch_data["scriptFile"] = os.path.join(self.jobDirectory(), os.path.basename(dispatch_data["scriptNode"]["fileName"].getValue()) or "untitled.gfr")
-        dispatch_data["scriptFile"] = dispatch_data["scriptFile"].replace("\\", os.sep).replace("/", os.sep)
+        dispatch_data["scriptFile"] = os.path.join(
+            self.jobDirectory(),
+            os.path.basename(
+                dispatch_data["scriptNode"]["fileName"].getValue()
+            ) or "untitled.gfr"
+        )
+        dispatch_data["scriptFile"] = dispatch_data["scriptFile"].replace("\\", os.sep).replace(
+            "/",
+            os.sep
+        )
 
         dispatch_data["scriptNode"].serialiseToFile(dispatch_data["scriptFile"])
 
         context = Gaffer.Context.current()
-        dispatch_data["deadlineBatch"] = context.substitute(self["jobName"].getValue()) or "untitled"
+        dispatch_data["deadlineBatch"] = (
+            context.substitute(self["jobName"].getValue()) or "untitled"
+        )
 
         root_deadline_job = GafferDeadlineJob()
         root_deadline_job.setGafferNode(root_batch.node())
@@ -115,9 +134,10 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
 
         for root_job in root_jobs:
             self.__buildDeadlineDependencyWalk(root_job)
-            # Control jobs with nothing to control should be removed after the dependencies are set up.
-            # This mostly applies to FrameMask nodes where downstream nodes need to see tasks on the FrameMask
-            # to trigger Job-Job dependency mode, but those tasks should not be submitted to Deadline.
+            # Control jobs with nothing to control should be removed after the dependencies are
+            # set up. This mostly applies to FrameMask nodes where downstream nodes need to see
+            # tasks on the FrameMask to trigger Job-Job dependency mode, but those tasks should
+            # not be submitted to Deadline.
             self.__removeOrphanTasksWalk(root_job)
             self.__submitDeadlineJob(root_job, dispatch_data)
 
@@ -168,7 +188,11 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
             self.__submitDeadlineJob(parent_job, dispatch_data)
 
         gaffer_node = deadline_job.getGafferNode()
-        if gaffer_node is None or len(deadline_job.getTasks()) == 0 or len(deadline_job.getTasks()) == 0:
+        if (
+            gaffer_node is None or
+            len(deadline_job.getTasks()) == 0 or
+            len(deadline_job.getTasks()) == 0
+        ):
             return None
 
         # this job is already submitted if it has an ID
@@ -180,11 +204,19 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
         deadline_plug = gaffer_node["dispatcher"].getChild("deadline")
 
         if deadline_plug is not None:
-            initial_status = "Suspended" if deadline_plug["submitSuspended"].getValue() else "Active"
-            machine_list_type = "Blacklist" if deadline_plug["isBlackList"].getValue() else "Whitelist"
-            
-            # to prevent Deadline from splitting up our tasks (since we've already done that based on batches), set the chunk size to the largest frame range
-            chunk_size = deadline_job.getTasks()[0].getEndFrame() - deadline_job.getTasks()[0].getStartFrame() + 1
+            initial_status = (
+                "Suspended" if deadline_plug["submitSuspended"].getValue() else "Active"
+            )
+            machine_list_type = (
+                "Blacklist" if deadline_plug["isBlackList"].getValue() else "Whitelist"
+            )
+
+            # to prevent Deadline from splitting up our tasks (since we've already done that based
+            # on batches), set the chunk size to the largest frame range
+            chunk_size = (
+                deadline_job.getTasks()[0].getEndFrame() -
+                deadline_job.getTasks()[0].getStartFrame() + 1
+            )
             frame_string = ""
             for t in deadline_job.getTasks():
                 chunk_size = max(t.getEndFrame() - t.getStartFrame() + 1, chunk_size)
@@ -192,7 +224,7 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
                     frame_string += ",{}".format(t.getStartFrame())
                 else:
                     frame_string += ",{}-{}".format(t.getStartFrame(), t.getEndFrame())
-            
+
             context = deadline_job.getContext()
             job_info = {"Name": gaffer_node.relativeName(dispatch_data["scriptNode"]),
                         "Frames": frame_string,
@@ -202,14 +234,18 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
                         "Comment": context.substitute(deadline_plug["comment"].getValue()),
                         "Department": context.substitute(deadline_plug["department"].getValue()),
                         "Pool": context.substitute(deadline_plug["pool"].getValue()),
-                        "SecondaryPool": context.substitute(deadline_plug["secondaryPool"].getValue()),
+                        "SecondaryPool": context.substitute(
+                            deadline_plug["secondaryPool"].getValue()
+                        ),
                         "Group": context.substitute(deadline_plug["group"].getValue()),
                         "Priority": deadline_plug["priority"].getValue(),
                         "TaskTimeoutMinutes": int(deadline_plug["taskTimeout"].getValue()),
                         "EnableAutoTimeout": deadline_plug["enableAutoTimeout"].getValue(),
                         "ConcurrentTasks": deadline_plug["concurrentTasks"].getValue(),
                         "MachineLimit": deadline_plug["machineLimit"].getValue(),
-                        machine_list_type: context.substitute(deadline_plug["machineList"].getValue()),
+                        machine_list_type: context.substitute(
+                            deadline_plug["machineList"].getValue()
+                        ),
                         "LimitGroups": context.substitute(deadline_plug["limits"].getValue()),
                         "OnJobComplete": deadline_plug["onJobComplete"].getValue(),
                         "InitialStatus": initial_status,
@@ -230,26 +266,28 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
             for name, value in deadlineSettings.items():
                 deadline_job.appendDeadlineSetting(name, context.substitute(str(value)))
 
-            """ Dependencies are stored with a reference to the Deadline job since job IDs weren't assigned
-            when the task tree was walked. Now that parent jobs have been submitted and have IDs,
-            we can substitute that in for the dependency script to pick up.
+            """ Dependencies are stored with a reference to the Deadline job since job IDs weren't
+            assigned when the task tree was walked. Now that parent jobs have been submitted and
+            have IDs, we can substitute that in for the dependency script to pick up.
 
-            We also want to dependencies to be as native to Deadline as possible, resorting to the dependency
-            script only in cases where it is needed (Deadline's dependency script triggering seems to be slower
-            than native task dependencies)
+            We also want to dependencies to be as native to Deadline as possible, resorting to the
+            dependency script only in cases where it is needed (Deadline's dependency script
+            triggering seems to be slower than native task dependencies)
 
             There are three possible dependency types allowed by Deadline:
-            1) Job-Job:     All of the tasks for job A wait for all of the tasks for job B to finish before job A runs.
-                            This is relatively rare when coming from Deadline and mostly is used by nodes upstream from
-                            a FrameMask node. In that case releasing tasks per-frame would trigger downstream jobs sooner
-                            than they should.
-            2) Frame-Frame: This is somewhat misleadingly named because Deadline only checks for frame dependency release 
-                            after each task completes, so this is very similar to task-task dependencies. Deadline can 
-                            only handle a start and end frame offset when comparing to the parent job so the task
+            1) Job-Job:     All of the tasks for job A wait for all of the tasks for job B to
+                            finish before job A runs. This is relatively rare when coming from
+                            Deadline and mostly is used by nodes upstream from a FrameMask node.
+                            In that case releasing tasks per-frame would trigger downstream jobs
+                            sooner than they should.
+            2) Frame-Frame: This is somewhat misleadingly named because Deadline only checks for
+                            frame dependency release after each task completes, so this is very
+                            similar to task-task dependencies. Deadline can only handle a start
+                            and end frame offset when comparing to the parent job so the task
                             offsets must match across all parent jobs to enable this mode.
-            3) Task-Task:   A task for job A waits for a task for job B to finish before the task for job A runs.
-                            If the dependency start and end frame offsets don't match, this has to be handled by a
-                            dependency script.
+            3) Task-Task:   A task for job A waits for a task for job B to finish before the task
+                            for job A runs. If the dependency start and end frame offsets don't
+                            match, this has to be handled by a dependency script.
             """
             dep_list = deadline_job.getDependencies()
 
@@ -266,20 +304,42 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
                     dep_jobs = [j["dependency_job"] for j in dep_list]
                     dep_jobs = list(set(dep_jobs))
                     for dep in dep_list:
-                        if dep["dependency_task"].getStartFrame() is None or dep["dependency_task"].getEndFrame() is None:
+                        if (
+                            dep["dependency_task"].getStartFrame() is None or
+                            dep["dependency_task"].getEndFrame() is None
+                        ):
                             job_dependent = True
 
                     frame_dependent = True
                     simple_frame_offset = True
-                    if len(dep_list) > 0 and dep_list[0]["dependency_task"].getStartFrame() is not None and dep_list[0]["dependency_task"].getEndFrame() is not None:
-                        deadline_job._frame_dependency_offset_start = dep_list[0]["dependency_task"].getStartFrame() - dep_list[0]["dependent_task"].getStartFrame()
-                        deadline_job._frame_dependency_offset_end = dep_list[0]["dependency_task"].getEndFrame() - dep_list[0]["dependent_task"].getEndFrame()
+                    if (
+                        len(dep_list) > 0 and
+                        dep_list[0]["dependency_task"].getStartFrame() is not None and
+                        dep_list[0]["dependency_task"].getEndFrame() is not None
+                    ):
+                        deadline_job._frame_dependency_offset_start = (
+                            dep_list[0]["dependency_task"].getStartFrame() -
+                            dep_list[0]["dependent_task"].getStartFrame()
+                        )
+                        deadline_job._frame_dependency_offset_end = (
+                            dep_list[0]["dependency_task"].getEndFrame() -
+                            dep_list[0]["dependent_task"].getEndFrame()
+                        )
 
                         for dep_task in dep_list:
-                            new_frame_offset_start = dep_task["dependency_task"].getStartFrame() - dep_task["dependent_task"].getStartFrame()
-                            new_frame_offset_end= dep_task["dependency_task"].getEndFrame() - dep_task["dependent_task"].getEndFrame()
+                            new_frame_offset_start = (
+                                dep_task["dependency_task"].getStartFrame() -
+                                dep_task["dependent_task"].getStartFrame()
+                            )
+                            new_frame_offset_end = (
+                                dep_task["dependency_task"].getEndFrame() -
+                                dep_task["dependent_task"].getEndFrame()
+                            )
 
-                            if new_frame_offset_start != deadline_job._frame_dependency_offset_start or new_frame_offset_end != deadline_job._frame_dependency_offset_end:
+                            if (
+                                new_frame_offset_start != deadline_job._frame_dependency_offset_start or
+                                new_frame_offset_end != deadline_job._frame_dependency_offset_end
+                            ):
                                 simple_frame_offset = False
                         
                         # If we can't just shift the frame start and end, we might still be able to use frame dependency with tasks of different frame lengths
@@ -287,16 +347,29 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
                             dep_jobs = [j["dependency_job"] for j in dep_list]
                             dep_jobs = list(set(dep_jobs))
                             for dep_job in dep_jobs:
-                                dep_tasks = [t["dependency_task"] for t in dep_list if t["dependency_job"] == dep_job]
+                                dep_tasks = [
+                                    t["dependency_task"] for t in dep_list if t["dependency_job"] == dep_job
+                                ]
                                 dep_frames = []
                                 for t in dep_tasks:
-                                    if t.getStartFrame() is not None and t.getEndFrame() is not None:
+                                    if (
+                                        t.getStartFrame() is not None and
+                                        t.getEndFrame() is not None
+                                    ):
                                         dep_frames += range(t.getStartFrame(), t.getEndFrame() + 1)
-                                current_tasks = [t["dependent_task"] for t in dep_list if t["dependency_job"] == dep_job]
+                                current_tasks = [
+                                    t["dependent_task"] for t in dep_list if t["dependency_job"] == dep_job
+                                ]
                                 current_frames = []
                                 for t in current_tasks:
-                                    if t.getStartFrame() is not None and t.getEndFrame() is not None:
-                                        current_frames += range(t.getStartFrame(), t.getEndFrame() + 1)
+                                    if (
+                                        t.getStartFrame() is not None and
+                                        t.getEndFrame() is not None
+                                    ):
+                                        current_frames += range(
+                                            t.getStartFrame(),
+                                            t.getEndFrame() + 1
+                                        )
                                 for f in current_frames:
                                     if f not in dep_frames:
                                         frame_dependent = False
@@ -307,7 +380,9 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
                 if job_dependent or frame_dependent:
                     job_info.update(
                         {
-                            "JobDependencies": ",".join(list(set([j["dependency_job"].getJobID() for j in dep_list]))),
+                            "JobDependencies": ",".join(
+                                list(set([j["dependency_job"].getJobID() for j in dep_list]))
+                            ),
                             "ResumeOnDeletedDependencies": True,
                         }
                     )
@@ -333,7 +408,9 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
                     for i in range(0,len(dep_list)):
                         dep_task = dep_list[i]
                         job_info["ExtraInfoKeyValue{}".format(i)] = "{}:{}={}".format(int(dep_task["dependent_task"].getTaskNumber()), dep_task["dependency_job"].getJobID(), dep_task["dependency_task"].getTaskNumber())
-                    deadline_job.setDependencyType(GafferDeadlineJob.DeadlineDependencyType.scripted)
+                    deadline_job.setDependencyType(
+                        GafferDeadlineJob.DeadlineDependencyType.scripted
+                    )
             else:
                 deadline_job.setDependencyType(GafferDeadlineJob.DeadlineDependencyType.none)
 
@@ -345,19 +422,42 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
                            }
             scriptContext = dispatch_data["scriptNode"].context()
             contextArgs = []
-            for entry in [k for k in deadline_job.getContext().keys() if k != "frame" and not k.startswith("ui:")]:
-                if entry not in scriptContext.keys() or deadline_job.getContext()[entry] != scriptContext[entry]:
-                    contextArgs.extend(["\"-{}\"".format(entry), "\"{}\"".format(repr(deadline_job.getContext()[entry]))])
+            for entry in [
+                k for k in deadline_job.getContext().keys() if k != "frame" and not k.startswith("ui:")
+            ]:
+                if (
+                    entry not in scriptContext.keys() or
+                    deadline_job.getContext()[entry] != scriptContext[entry]
+                ):
+                    contextArgs.extend(
+                        [
+                            "\"-{}\"".format(entry),
+                            "\"{}\"".format(repr(deadline_job.getContext()[entry]))
+                        ]
+                    )
             if contextArgs:
                 plugin_info["Context"] = " ".join(contextArgs)
 
             deadline_job.setJobProperties(job_info)
             deadline_job.setPluginProperties(plugin_info)
 
-            job_file_path = os.path.join(os.path.split(dispatch_data["scriptFile"])[0], gaffer_node.relativeName(dispatch_data["scriptNode"]) + ".job")
-            plugin_file_path = os.path.join(os.path.split(dispatch_data["scriptFile"])[0], gaffer_node.relativeName(dispatch_data["scriptNode"]) + ".plugin")
+            job_file_path = os.path.join(
+                os.path.split(
+                    dispatch_data["scriptFile"]
+                )[0],
+                gaffer_node.relativeName(dispatch_data["scriptNode"]) + ".job"
+            )
+            plugin_file_path = os.path.join(
+                os.path.split(
+                    dispatch_data["scriptFile"]
+                )[0],
+                gaffer_node.relativeName(dispatch_data["scriptNode"]) + ".plugin"
+            )
 
-            job_id, output = deadline_job.submitJob(job_file_path=job_file_path, plugin_file_path=plugin_file_path)
+            job_id, output = deadline_job.submitJob(
+                job_file_path=job_file_path,
+                plugin_file_path=plugin_file_path
+            )
             if job_id is None:
                 IECore.Log.error(job_info["Name"], "failed to submit to Deadline.", output)
             else:
@@ -380,10 +480,18 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
         parent_plug["deadline"]["pool"] = Gaffer.StringPlug()
         parent_plug["deadline"]["secondaryPool"] = Gaffer.StringPlug()
         parent_plug["deadline"]["group"] = Gaffer.StringPlug()
-        parent_plug["deadline"]["priority"] = Gaffer.IntPlug(defaultValue=50, minValue=0, maxValue=100)
+        parent_plug["deadline"]["priority"] = Gaffer.IntPlug(
+            defaultValue=50,
+            minValue=0,
+            maxValue=100
+        )
         parent_plug["deadline"]["taskTimeout"] = Gaffer.IntPlug(defaultValue=0, minValue=0)
         parent_plug["deadline"]["enableAutoTimeout"] = Gaffer.BoolPlug(defaultValue=False)
-        parent_plug["deadline"]["concurrentTasks"] = Gaffer.IntPlug(defaultValue=1, minValue=1, maxValue=16)
+        parent_plug["deadline"]["concurrentTasks"] = Gaffer.IntPlug(
+            defaultValue=1,
+            minValue=1,
+            maxValue=16
+        )
         parent_plug["deadline"]["machineLimit"] = Gaffer.IntPlug(defaultValue=0, minValue=0)
         parent_plug["deadline"]["machineList"] = Gaffer.StringPlug()
         parent_plug["deadline"]["isBlackList"] = Gaffer.BoolPlug(defaultValue=False)
@@ -393,10 +501,17 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
         parent_plug["deadline"]["submitSuspended"] = Gaffer.BoolPlug(defaultValue=False)
         parent_plug["deadline"]["dependencyMode"] = Gaffer.StringPlug()
         parent_plug["deadline"]["dependencyMode"].setValue("Auto")
-        parent_plug["deadline"]["auxFiles"] = Gaffer.StringVectorDataPlug(defaultValue=IECore.StringVectorData())
+        parent_plug["deadline"]["auxFiles"] = Gaffer.StringVectorDataPlug(
+            defaultValue=IECore.StringVectorData()
+        )
         parent_plug["deadline"]["deadlineSettings"] = Gaffer.CompoundDataPlug()
         parent_plug["deadline"]["environmentVariables"] = Gaffer.CompoundDataPlug()
 
+
 IECore.registerRunTimeTyped(DeadlineDispatcher, typeName="GafferDeadline::DeadlineDispatcher")
 
-GafferDispatch.Dispatcher.registerDispatcher("Deadline", DeadlineDispatcher, DeadlineDispatcher._setupPlugs)
+GafferDispatch.Dispatcher.registerDispatcher(
+    "Deadline",
+    DeadlineDispatcher,
+    DeadlineDispatcher._setupPlugs
+)

--- a/python/GafferDeadline/DeadlineDispatcher.py
+++ b/python/GafferDeadline/DeadlineDispatcher.py
@@ -77,26 +77,24 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
                             it depending on batch and context layout. A DeadlineJob is defined by
                             the combination of Gaffer TaskNode and Context.
         Gaffer Job = set of Deadline Jobs (could be considered a Deadline Batch)
+
         Use DeadlineJob, DeadlineTask, etc. to denote Deadline terminology and plain Batch, Job,
-                            etc. to denote Gaffer terminology.
+        etc. to denote Gaffer terminology.
 
         Batches can have dependencies completely independent of frame numbers. First
         walk through the batch tree to build up a set of GafferDeadlineJob objects with
-                            GafferDeadlineTask objects corresponding to the batches.
+        GafferDeadlineTask objects corresponding to the batches.
 
         When all tasks are created, go back through the tree to setup dependencies between tasks.
-                            Task dependencies may be different
-        from Batch dependencies because batches may have been split to accommodate Deadline's
-                            sequential frame task requirement.
+        Task dependencies may be different from Batch dependencies because batches may have been
+        split to accommodate Deadline's sequential frame task requirement.
 
         With dependencies set, start at the leaf nodes of the task tree (no upstream DeadlineJobs)
-                            and submit those first. That way
-        the Deadline Job ID can be stored and used by dependent jobs to set their dependencies
-                            correctly.
+        and submit those first. That way the Deadline Job ID can be stored and used by dependent
+        jobs to set their dependencies correctly.
 
         To be compatible with Deadline's ExtraInfoKeyValue system, dependencies are reformatted at
-                            submission as
-        task:jobDependencyId=taskDependencyNumber
+        submission as task:jobDependencyId=taskDependencyNumber
         '''
         self._deadlineJobs = []
         IECore.Log.info("Beginning Deadline submission")

--- a/python/GafferDeadline/DeadlineDispatcher.py
+++ b/python/GafferDeadline/DeadlineDispatcher.py
@@ -41,7 +41,7 @@ import IECore
 import Gaffer
 import GafferDispatch
 
-import GafferDeadline
+from .GafferDeadlineJob import GafferDeadlineJob
 
 
 class DeadlineDispatcher(GafferDispatch.Dispatcher):
@@ -101,7 +101,7 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
         context = Gaffer.Context.current()
         dispatch_data["deadlineBatch"] = context.substitute(self["jobName"].getValue()) or "untitled"
 
-        root_deadline_job = GafferDeadline.GafferDeadlineJob()
+        root_deadline_job = GafferDeadlineJob()
         root_deadline_job.setGafferNode(root_batch.node())
         root_deadline_job.setAuxFiles([dispatch_data["scriptFile"]])
         self.__addGafferDeadlineJob(root_deadline_job)
@@ -127,7 +127,7 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
 
         deadline_job = self.__getGafferDeadlineJob(batch.node(), batch.context())
         if not deadline_job:
-            deadline_job = GafferDeadline.GafferDeadlineJob()
+            deadline_job = GafferDeadlineJob()
             deadline_job.setGafferNode(batch.node())
             deadline_job.setContext(batch.context())
             deadline_job.setAuxFiles([dispatch_data["scriptFile"]])
@@ -320,9 +320,9 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
                         )
                     if frame_dependent:
                         job_info.update({"IsFrameDependent": True})
-                        deadline_job.setDependencyType(GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frame_to_frame)
+                        deadline_job.setDependencyType(GafferDeadlineJob.DeadlineDependencyType.frame_to_frame)
                     else:
-                        deadline_job.setDependencyType(GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.job_to_job)
+                        deadline_job.setDependencyType(GafferDeadlineJob.DeadlineDependencyType.job_to_job)
                 else:
                     job_info.update(
                         {
@@ -333,9 +333,9 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
                     for i in range(0,len(dep_list)):
                         dep_task = dep_list[i]
                         job_info["ExtraInfoKeyValue{}".format(i)] = "{}:{}={}".format(int(dep_task["dependent_task"].getTaskNumber()), dep_task["dependency_job"].getJobID(), dep_task["dependency_task"].getTaskNumber())
-                    deadline_job.setDependencyType(GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.scripted)
+                    deadline_job.setDependencyType(GafferDeadlineJob.DeadlineDependencyType.scripted)
             else:
-                deadline_job.setDependencyType(GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.none)
+                deadline_job.setDependencyType(GafferDeadlineJob.DeadlineDependencyType.none)
 
             plugin_info = {"Script": os.path.split(dispatch_data["scriptFile"])[-1],
                            "Version": Gaffer.About.versionString(),

--- a/python/GafferDeadline/DeadlineTools.py
+++ b/python/GafferDeadline/DeadlineTools.py
@@ -45,7 +45,10 @@ def runDeadlineCommand(arguments, hideWindow=True):
     if "DEADLINE_PATH" not in os.environ:
         raise RuntimeError("DEADLINE_PATH must be set to the Deadline executable path")
     executable_suffix = ".exe" if os.name == "nt" else ""
-    deadline_command = os.path.join(os.environ['DEADLINE_PATH'], "deadlinecommand" + executable_suffix)
+    deadline_command = os.path.join(
+        os.environ['DEADLINE_PATH'],
+        "deadlinecommand" + executable_suffix
+    )
 
     arguments = [deadline_command] + arguments
 
@@ -54,7 +57,12 @@ def runDeadlineCommand(arguments, hideWindow=True):
     output, err = p.communicate()
 
     if err:
-        raise RuntimeError("Error running Deadline command {}: {}".format(" ".join(arguments), output))
+        raise RuntimeError(
+            "Error running Deadline command {}: {}".format(
+                " ".join(arguments),
+                output
+            )
+        )
 
     return output
 

--- a/python/GafferDeadline/DeadlineTools.py
+++ b/python/GafferDeadline/DeadlineTools.py
@@ -70,7 +70,8 @@ def runDeadlineCommand(arguments, hideWindow=True):
 def submitJob(jobInfoFile, pluginInfoFile, auxFiles):
     submissionResults = runDeadlineCommand([jobInfoFile, pluginInfoFile] + auxFiles)
 
-    for line in submissionResults.split():
+    for i in submissionResults.split():
+        line = i.decode()
         if line.startswith("JobID="):
             jobID = line.replace("JobID=", "").strip()
             return (jobID, submissionResults)
@@ -80,19 +81,19 @@ def submitJob(jobInfoFile, pluginInfoFile, auxFiles):
 
 def getMachineList():
     output = runDeadlineCommand(["GetSlaveNames"])
-    return output.split()
+    return [i.decode() for i in output.split()]
 
 
 def getLimitGroups():
     output = runDeadlineCommand(["GetLimitGroups"])
-    return re.findall(r'Name=(.*)', output)
+    return re.findall(r'Name=(.*)', output.decode())
 
 
 def getGroups():
     output = runDeadlineCommand(["GetSubmissionInfo", "groups"])
-    return output.split()[1:]    # remove [Groups] header
+    return [i.decode() for i in output.split()[1:]]    # remove [Groups] header
 
 
 def getPools():
     output = runDeadlineCommand(["GetSubmissionInfo", "pools"])
-    return output.split()[1:]    # remove [Groups] header
+    return [i.decode() for i in output.split()[1:]]    # remove [Groups] header

--- a/python/GafferDeadline/DeadlineTools.py
+++ b/python/GafferDeadline/DeadlineTools.py
@@ -44,13 +44,13 @@ import IECore
 def runDeadlineCommand(arguments, hideWindow=True):
     if "DEADLINE_PATH" not in os.environ:
         raise RuntimeError("DEADLINE_PATH must be set to the Deadline executable path")
-    executable_suffix = ".exe" if os.name == "nt" else ""
-    deadline_command = os.path.join(
+    executableSuffix = ".exe" if os.name == "nt" else ""
+    deadlineCommand = os.path.join(
         os.environ['DEADLINE_PATH'],
-        "deadlinecommand" + executable_suffix
+        "deadlinecommand" + executableSuffix
     )
 
-    arguments = [deadline_command] + arguments
+    arguments = [deadlineCommand] + arguments
 
     p = subprocess.Popen(arguments, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
@@ -67,15 +67,15 @@ def runDeadlineCommand(arguments, hideWindow=True):
     return output
 
 
-def submitJob(job_info_file, plugin_info_file, aux_files):
-    submission_results = runDeadlineCommand([job_info_file, plugin_info_file] + aux_files)
+def submitJob(jobInfoFile, pluginInfoFile, auxFiles):
+    submissionResults = runDeadlineCommand([jobInfoFile, pluginInfoFile] + auxFiles)
 
-    for line in submission_results.split():
+    for line in submissionResults.split():
         if line.startswith("JobID="):
             jobID = line.replace("JobID=", "").strip()
-            return (jobID, submission_results)
+            return (jobID, submissionResults)
 
-    return (None, submission_results)
+    return (None, submissionResults)
 
 
 def getMachineList():

--- a/python/GafferDeadline/GafferDeadlineJob.py
+++ b/python/GafferDeadline/GafferDeadlineJob.py
@@ -40,8 +40,9 @@ import tempfile
 import IECore
 
 import GafferDispatch
-import GafferDeadline
-import DeadlineTools
+
+from . import DeadlineTools
+from .GafferDeadlineTask import GafferDeadlineTask
 
 
 class GafferDeadlineJob(object):
@@ -156,18 +157,18 @@ class GafferDeadlineJob(object):
         # some TaskNodes like TaskList and TaskWedge submit with no frames because they are just hierarchy placeholders
         # they still need to be in for proper dependency handling
         if len(batch_frames) > 0:
-            current_task = GafferDeadline.GafferDeadlineTask(new_batch, len(self.getTasks()), start_frame=batch_frames[0], end_frame=batch_frames[0])
+            current_task = GafferDeadlineTask(new_batch, len(self.getTasks()), start_frame=batch_frames[0], end_frame=batch_frames[0])
             self._tasks.append(current_task)
             for i in range(1, len(batch_frames)):
                 if (batch_frames[i] - batch_frames[i-1]) > 1:
-                    current_task = GafferDeadline.GafferDeadlineTask(new_batch, len(self.getTasks()), start_frame=batch_frames[i], end_frame=batch_frames[i])
+                    current_task = GafferDeadlineTask(new_batch, len(self.getTasks()), start_frame=batch_frames[i], end_frame=batch_frames[i])
                     self._tasks.append(current_task)
                 else:
                     current_task.setEndFrame(batch_frames[i])
         else:
             # Control nodes like TaskList have no frames but do need tasks created to pass
             # through dependencies
-            self._tasks.append(GafferDeadline.GafferDeadlineTask(new_batch, len(self.getTasks())))
+            self._tasks.append(GafferDeadlineTask(new_batch, len(self.getTasks())))
 
     def getTasksForBatch(self, batch):
         task_list = [t for t in self.getTasks() if t.getGafferBatch() == batch]

--- a/python/GafferDeadline/GafferDeadlineJob.py
+++ b/python/GafferDeadline/GafferDeadlineJob.py
@@ -54,105 +54,105 @@ class GafferDeadlineJob(object):
 
     class DeadlineDependencyType(object):
         none = 0
-        job_to_job = 1
-        frame_to_frame = 2
+        jobToJob = 1
+        frameToFrame = 2
         scripted = 3
 
     def __init__(
         self,
-        job_properties={},
-        plugin_properties={},
-        aux_files=[],
+        jobProperties={},
+        pluginProperties={},
+        auxFiles=[],
         deadlineSettings={},
         environmentVariables={},
-        gaffer_node=None,
-        job_context={},
-        chunk_size=1
+        gafferNode=None,
+        jobContext={},
+        chunkSize=1
     ):
-        self._dependency_type = None
-        self._frame_dependency_offset_start = 0
-        self._frame_dependency_offset_end = 0
+        self._dependencyType = None
+        self._frameDependencyOffsetStart = 0
+        self._frameDependencyOffsetEnd = 0
 
-        self.setJobProperties(job_properties)
-        self.setPluginProperties(plugin_properties)
-        self.setAuxFiles(aux_files)
-        self.setGafferNode(gaffer_node)
-        self.setContext(job_context)
+        self.setJobProperties(jobProperties)
+        self.setPluginProperties(pluginProperties)
+        self.setAuxFiles(auxFiles)
+        self.setGafferNode(gafferNode)
+        self.setContext(jobContext)
 
         self._deadlineSettings = deadlineSettings.copy()
         self._environmentVariables = environmentVariables.copy()
-        self._job_id = None
-        self._parent_jobs = []
+        self._jobId = None
+        self._parentJobs = []
         self._tasks = []
         # dependencies are of the dictionary form
         # {
-        #   "dependency_job": <GafferDeadlineJob>,
-        #   "dependent_task": <GafferDeadlineTask for this job>,
-        #   "dependency_task": <GafferDeadlineTask for parent job>
+        #   "dependencyJob": <GafferDeadlineJob>,
+        #   "dependentTask": <GafferDeadlineTask for this job>,
+        #   "dependencyTask": <GafferDeadlineTask for parent job>
         # }
         self._dependencies = []
 
-    def setJobProperties(self, new_properties):
+    def setJobProperties(self, newProperties):
         """ The only parameter Deadline requires is Plugin and because we are
         focusing on Gaffer plugins, make sure that's always set.
         """
-        assert(type(new_properties) == dict)
-        self._job_properties = new_properties
-        self._job_properties.update({"Plugin": "Gaffer"})
+        assert(type(newProperties) == dict)
+        self._jobProperties = newProperties
+        self._jobProperties.update({"Plugin": "Gaffer"})
 
     def getJobProperties(self):
-        return self._job_properties
+        return self._jobProperties
 
-    def setDependencyType(self, dep_type):
-        self._dependency_type = dep_type
+    def setDependencyType(self, depType):
+        self._dependencyType = depType
 
     def getDependencyType(self):
-        return self._dependency_type
+        return self._dependencyType
 
-    def setPluginProperties(self, new_properties):
-        assert(type(new_properties) == dict)
-        self._plugin_properties = new_properties.copy()
+    def setPluginProperties(self, newProperties):
+        assert(type(newProperties) == dict)
+        self._pluginProperties = newProperties.copy()
 
     def getPluginProperties(self):
-        return self._plugin_properties
+        return self._pluginProperties
 
-    def setAuxFiles(self, new_aux_files):
-        assert(type(new_aux_files) == list or type(new_aux_files) == str)
-        new_aux_files = new_aux_files if type(new_aux_files) == list else [new_aux_files]
-        self._aux_files = new_aux_files
+    def setAuxFiles(self, newAuxFiles):
+        assert(type(newAuxFiles) == list or type(newAuxFiles) == str)
+        newAuxFiles = newAuxFiles if type(newAuxFiles) == list else [newAuxFiles]
+        self._auxFiles = newAuxFiles
 
     def getAuxFiles(self):
-        return self._aux_files
+        return self._auxFiles
 
     def getJobID(self):
-        return self._job_id
+        return self._jobId
 
-    def setGafferNode(self, new_node):
-        if not issubclass(type(new_node), GafferDispatch.TaskNode) and new_node is not None:
+    def setGafferNode(self, newNode):
+        if not issubclass(type(newNode), GafferDispatch.TaskNode) and newNode is not None:
             raise ValueError("Gaffer node must be a GafferDispatch.TaskNode or None")
-        self._gaffer_node = new_node
+        self._gafferNode = newNode
 
     def getGafferNode(self):
-        return self._gaffer_node
+        return self._gafferNode
 
-    def setContext(self, new_context):
-        self._context = new_context
+    def setContext(self, newContext):
+        self._context = newContext
 
     def getContext(self):
         return self._context
 
-    def addParentJob(self, parent_job):
-        if type(parent_job) != GafferDeadlineJob:
+    def addParentJob(self, parentJob):
+        if type(parentJob) != GafferDeadlineJob:
             raise ValueError("Parent job must be a GafferDeadlineJob")
-        if parent_job not in self._parent_jobs:
-            self._parent_jobs.append(parent_job)
+        if parentJob not in self._parentJobs:
+            self._parentJobs.append(parentJob)
 
     def getParentJobs(self):
-        return self._parent_jobs
+        return self._parentJobs
 
-    def getParentJobByGafferNode(self, gaffer_node):
-        for job in self._parent_jobs:
-            if job.getGafferNode() == gaffer_node:
+    def getParentJobByGafferNode(self, gafferNode):
+        for job in self._parentJobs:
+            if job.getGafferNode() == gafferNode:
                 return job
 
         return None
@@ -163,42 +163,42 @@ class GafferDeadlineJob(object):
     def appendDeadlineSetting(self, name, value):
         self._deadlineSettings[name] = value
 
-    # Separate batch_frames out so it can be unit tested. Gaffer does not allow creating
+    # Separate batchFrames out so it can be unit tested. Gaffer does not allow creating
     # _TaskBatch objects
-    def addBatch(self, new_batch, batch_frames):
+    def addBatch(self, newBatch, batchFrames):
         """ A batch corresponds to one or more Deadline Tasks
         Deadline Tasks must be sequential frames with only a start and end frame
         """
-        assert(new_batch is None or type(new_batch) == GafferDispatch.Dispatcher._TaskBatch)
+        assert(newBatch is None or type(newBatch) == GafferDispatch.Dispatcher._TaskBatch)
         # some TaskNodes like TaskList and TaskWedge submit with no frames because they are just
         # hierarchy placeholders they still need to be in for proper dependency handling
-        if len(batch_frames) > 0:
-            current_task = GafferDeadlineTask(
-                new_batch,
+        if len(batchFrames) > 0:
+            currentTask = GafferDeadlineTask(
+                newBatch,
                 len(self.getTasks()),
-                start_frame=batch_frames[0],
-                end_frame=batch_frames[0]
+                startFrame=batchFrames[0],
+                endFrame=batchFrames[0]
             )
-            self._tasks.append(current_task)
-            for i in range(1, len(batch_frames)):
-                if (batch_frames[i] - batch_frames[i-1]) > 1:
-                    current_task = GafferDeadlineTask(
-                        new_batch,
+            self._tasks.append(currentTask)
+            for i in range(1, len(batchFrames)):
+                if (batchFrames[i] - batchFrames[i-1]) > 1:
+                    currentTask = GafferDeadlineTask(
+                        newBatch,
                         len(self.getTasks()),
-                        start_frame=batch_frames[i],
-                        end_frame=batch_frames[i]
+                        startFrame=batchFrames[i],
+                        endFrame=batchFrames[i]
                     )
-                    self._tasks.append(current_task)
+                    self._tasks.append(currentTask)
                 else:
-                    current_task.setEndFrame(batch_frames[i])
+                    currentTask.setEndFrame(batchFrames[i])
         else:
             # Control nodes like TaskList have no frames but do need tasks created to pass
             # through dependencies
-            self._tasks.append(GafferDeadlineTask(new_batch, len(self.getTasks())))
+            self._tasks.append(GafferDeadlineTask(newBatch, len(self.getTasks())))
 
     def getTasksForBatch(self, batch):
-        task_list = [t for t in self.getTasks() if t.getGafferBatch() == batch]
-        return task_list
+        taskList = [t for t in self.getTasks() if t.getGafferBatch() == batch]
+        return taskList
 
     def getTasks(self):
         return self._tasks
@@ -208,20 +208,20 @@ class GafferDeadlineJob(object):
         ultimately need to be linked. But there may be more than one task for a particular batch.
         """
         for task in self.getTasks():
-            for job in self._parent_jobs:
-                for parent_batch in task.getGafferBatch().preTasks():
-                    dependency_tasks = job.getTasksForBatch(parent_batch)
-                    for dep in dependency_tasks:
+            for job in self._parentJobs:
+                for parentBatch in task.getGafferBatch().preTasks():
+                    dependencyTasks = job.getTasksForBatch(parentBatch)
+                    for dep in dependencyTasks:
                         # Control tasks should have their frames set to the upstream frame range
                         # effectively making them frame-frame dependent
                         if task.getStartFrame() is None or task.getEndFrame() is None:
                             task.setFrameRange(dep.getStartFrame(), dep.getEndFrame())
-                        dep_dict = {
-                            "dependency_job": job,
-                            "dependent_task": task,
-                            "dependency_task": dep
+                        depDict = {
+                            "dependencyJob": job,
+                            "dependentTask": task,
+                            "dependencyTask": dep
                         }
-                        self._dependencies.append(dep_dict)
+                        self._dependencies.append(depDict)
 
     def removeOrphanTasks(self):
         self._tasks = [
@@ -235,10 +235,10 @@ class GafferDeadlineJob(object):
     def getDependencies(self):
         return self._dependencies
 
-    def submitJob(self, job_file_path=None, plugin_file_path=None):
+    def submitJob(self, jobFilePath=None, pluginFilePath=None):
         """ Submit the job to Deadline.
-        Returns a tuple of (submitted_job_id, Deadline_status_output). submitted_job_id
-        will be None if submission failed. Deadline_status_output can be used to help figure out
+        Returns a tuple of (submittedJobId, deadlineStatusOutput). submittedJobId
+        will be None if submission failed. deadlineStatusOutput can be used to help figure out
         why it failed.
 
         Check to make sure that all auxiliary files exist, otherwise submission will fail
@@ -249,25 +249,25 @@ class GafferDeadlineJob(object):
         Job and plugin files are just serializations of their respective dictionaries in the
         form of key=value separated by newlines.
 
-        If the job_file or plugin_file are not supplied, create temp files for them.
+        If the jobFile or pluginFile are not supplied, create temp files for them.
         Only remove temp files, not supplied files.
         """
-        for aux_file in self._aux_files:
-            if not os.path.isfile(aux_file):
-                raise IOError("{} does not exist".format(aux_file))
+        for auxFile in self._auxFiles:
+            if not os.path.isfile(auxFile):
+                raise IOError("{} does not exist".format(auxFile))
 
-        if job_file_path is None:
-            job_file = tempfile.NamedTemporaryFile(mode="w", suffix=".info", delete=False)
+        if jobFilePath is None:
+            jobFile = tempfile.NamedTemporaryFile(mode="w", suffix=".info", delete=False)
         else:
-            job_file = open(job_file_path, mode="w")
+            jobFile = open(jobFilePath, mode="w")
 
-        self._job_properties.update(self._deadlineSettings)
-        job_lines = [
-            "{}={}".format(k, self._job_properties[k]) for k in self._job_properties.keys()
+        self._jobProperties.update(self._deadlineSettings)
+        jobLines = [
+            "{}={}".format(k, self._jobProperties[k]) for k in self._jobProperties.keys()
         ]
         environmentVariableCounter = 0
         for v in self._environmentVariables.keys():
-            job_lines.append(
+            jobLines.append(
                 "EnvironmentKeyValue{}={}={}".format(
                     environmentVariableCounter,
                     v,
@@ -277,39 +277,39 @@ class GafferDeadlineJob(object):
             environmentVariableCounter += 1
         # Default to IECORE_LOG_LEVEL=INFO
         if "IECORE_LOG_LEVEL" not in self._environmentVariables:
-            job_lines.append(
+            jobLines.append(
                 "EnvironmentKeyValue{}=IECORE_LOG_LEVEL=INFO".format(
                     environmentVariableCounter
                 )
             )
 
-        job_file.write("\n".join(job_lines))
-        job_file.close()
+        jobFile.write("\n".join(jobLines))
+        jobFile.close()
 
-        if plugin_file_path is None:
-            plugin_file = tempfile.NamedTemporaryFile(mode="w", suffix=".info", delete=False)
+        if pluginFilePath is None:
+            pluginFile = tempfile.NamedTemporaryFile(mode="w", suffix=".info", delete=False)
         else:
-            plugin_file = open(plugin_file_path, mode="w")
-        plugin_lines = [
+            pluginFile = open(pluginFilePath, mode="w")
+        pluginLines = [
             "{}={}".format(
                 k,
-                self._plugin_properties[k]
-            ) for k in self._plugin_properties.keys()
+                self._pluginProperties[k]
+            ) for k in self._pluginProperties.keys()
         ]
-        plugin_file.write("\n".join(plugin_lines))
-        plugin_file.close()
+        pluginFile.write("\n".join(pluginLines))
+        pluginFile.close()
 
-        result = DeadlineTools.submitJob(job_file.name, plugin_file.name, self._aux_files)
+        result = DeadlineTools.submitJob(jobFile.name, pluginFile.name, self._auxFiles)
 
         IECore.Log.debug("Submission results:", result)
 
         if result[0] is None:
             raise RuntimeError("Deadline submission failed: \n{}".format(result[1]))
-        self._job_id = result[0]
+        self._jobId = result[0]
 
-        if job_file is None:
-            os.remove(job_file)
-        if plugin_file is None:
-            os.remove(plugin_file)
+        if jobFile is None:
+            os.remove(jobFile)
+        if pluginFile is None:
+            os.remove(pluginFile)
 
-        return (self._job_id, result[1])
+        return (self._jobId, result[1])

--- a/python/GafferDeadline/GafferDeadlineTask.py
+++ b/python/GafferDeadline/GafferDeadlineTask.py
@@ -36,6 +36,7 @@
 
 import GafferDispatch
 
+
 class GafferDeadlineTask(object):
     """ Mimic the Deadline representation of a task:
     - tasks are a sequential range of frames indicated by the start frame and end frame
@@ -50,9 +51,13 @@ class GafferDeadlineTask(object):
         self.setEndFrame(end_frame)
         self.setTaskNumber(task_number)
 
-        if self._start_frame is None and self.getGafferBatch() is not None and len(self.getGafferBatch().frames()) > 0:
+        if self._start_frame is None and self.getGafferBatch() is not None and len(
+            self.getGafferBatch().frames()
+        ) > 0:
             self.setStartFrame(gaffer_batch.frames()[0])
-        if self._end_frame is None and self.getGafferBatch() is not None and len(self.getGafferBatch().frames()) > 0:
+        if self._end_frame is None and self.getGafferBatch() is not None and len(
+            self.getGafferBatch().frames()
+        ) > 0:
             self.setEndFrame(gaffer_batch.frames()[len(gaffer_batch.frames()) - 1])
 
     def setTaskNumber(self, task_number):
@@ -97,7 +102,11 @@ class GafferDeadlineTask(object):
             self.setEndFrame(None)
 
     def setStartFrame(self, start_frame):
-        if self._end_frame is not None and start_frame is not None and start_frame > self._end_frame:
+        if (
+            self._end_frame is not None and
+            start_frame is not None and
+            start_frame > self._end_frame
+        ):
             raise ValueError("Start frame must be less than end frame.")
         if start_frame is not None:
             if int(start_frame) != start_frame:
@@ -110,7 +119,11 @@ class GafferDeadlineTask(object):
         return self._start_frame
 
     def setEndFrame(self, end_frame):
-        if self._start_frame is not None and end_frame is not None and end_frame < self._start_frame:
+        if (
+            self._start_frame is not None and
+            end_frame is not None and
+            end_frame < self._start_frame
+        ):
             raise ValueError("End frame must be greater than start frame.")
         if end_frame is not None:
             if int(end_frame) != end_frame:

--- a/python/GafferDeadline/GafferDeadlineTask.py
+++ b/python/GafferDeadline/GafferDeadlineTask.py
@@ -42,95 +42,95 @@ class GafferDeadlineTask(object):
     - tasks are a sequential range of frames indicated by the start frame and end frame
     - tasks can only be associated with one job and therefore one batch / Gaffer Task Node
     """
-    def __init__(self, gaffer_batch, task_number, start_frame=None, end_frame=None):
-        self._start_frame = None
-        self._end_frame = None
+    def __init__(self, gafferBatch, taskNumber, startFrame=None, endFrame=None):
+        self._startFrame = None
+        self._endFrame = None
 
-        self.setGafferBatch(gaffer_batch)
-        self.setStartFrame(start_frame)
-        self.setEndFrame(end_frame)
-        self.setTaskNumber(task_number)
+        self.setGafferBatch(gafferBatch)
+        self.setStartFrame(startFrame)
+        self.setEndFrame(endFrame)
+        self.setTaskNumber(taskNumber)
 
-        if self._start_frame is None and self.getGafferBatch() is not None and len(
+        if self._startFrame is None and self.getGafferBatch() is not None and len(
             self.getGafferBatch().frames()
         ) > 0:
-            self.setStartFrame(gaffer_batch.frames()[0])
-        if self._end_frame is None and self.getGafferBatch() is not None and len(
+            self.setStartFrame(gafferBatch.frames()[0])
+        if self._endFrame is None and self.getGafferBatch() is not None and len(
             self.getGafferBatch().frames()
         ) > 0:
-            self.setEndFrame(gaffer_batch.frames()[len(gaffer_batch.frames()) - 1])
+            self.setEndFrame(gafferBatch.frames()[len(gafferBatch.frames()) - 1])
 
-    def setTaskNumber(self, task_number):
-        assert(type(task_number) == int)
-        self._task_number = task_number
+    def setTaskNumber(self, taskNumber):
+        assert(type(taskNumber) == int)
+        self._taskNumber = taskNumber
 
     def getTaskNumber(self):
-        return self._task_number
+        return self._taskNumber
 
-    def setGafferBatch(self, gaffer_batch):
-        assert(gaffer_batch is None or type(gaffer_batch) == GafferDispatch.Dispatcher._TaskBatch)
-        self._gaffer_batch = gaffer_batch
+    def setGafferBatch(self, gafferBatch):
+        assert(gafferBatch is None or type(gafferBatch) == GafferDispatch.Dispatcher._TaskBatch)
+        self._gafferBatch = gafferBatch
 
     def getGafferBatch(self):
-        return self._gaffer_batch
+        return self._gafferBatch
 
-    def setFrameRange(self, start_frame, end_frame):
-        if end_frame < start_frame:
+    def setFrameRange(self, startFrame, endFrame):
+        if endFrame < startFrame:
             raise ValueError("End frame must be greater than start frame.")
-        if int(start_frame) != start_frame or int(end_frame) != end_frame:
+        if int(startFrame) != startFrame or int(endFrame) != endFrame:
             raise ValueError("Start and end frames must be integers.")
-        self._start_frame = int(start_frame)
-        self._end_frame = int(end_frame)
+        self._startFrame = int(startFrame)
+        self._endFrame = int(endFrame)
 
-    def setFrameRangeFromList(self, frame_list):
-        frames_sequential = True
-        if len(frame_list) > 0:
-            if int(frame_list[0]) != frame_list[0]:
+    def setFrameRangeFromList(self, frameList):
+        framesSequential = True
+        if len(frameList) > 0:
+            if int(frameList[0]) != frameList[0]:
                 raise ValueError("Frame numbers must be integers.")
-            for i in range(1, len(frame_list)-1):
-                if int(frame_list[i]) != frame_list[i]:
+            for i in range(1, len(frameList)-1):
+                if int(frameList[i]) != frameList[i]:
                     raise ValueError("Frame numbers must be integers.")
-                if frame_list[i] - frame_list[i-1] != 1:
-                    frames_sequential = False
+                if frameList[i] - frameList[i-1] != 1:
+                    framesSequential = False
 
-            if not frames_sequential:
+            if not framesSequential:
                 raise ValueError("Frame list must be sequential.")
-            self._start_frame = int(frame_list[0])
-            self._end_frame = int(frame_list[len(frame_list) - 1])
+            self._startFrame = int(frameList[0])
+            self._endFrame = int(frameList[len(frameList) - 1])
         else:
             self.setStartFrame(None)
             self.setEndFrame(None)
 
-    def setStartFrame(self, start_frame):
+    def setStartFrame(self, startFrame):
         if (
-            self._end_frame is not None and
-            start_frame is not None and
-            start_frame > self._end_frame
+            self._endFrame is not None and
+            startFrame is not None and
+            startFrame > self._endFrame
         ):
             raise ValueError("Start frame must be less than end frame.")
-        if start_frame is not None:
-            if int(start_frame) != start_frame:
+        if startFrame is not None:
+            if int(startFrame) != startFrame:
                 raise ValueError("Frame numbers must be integers.")
-            self._start_frame = int(start_frame)
+            self._startFrame = int(startFrame)
         else:
-            self._start_frame = None
+            self._startFrame = None
 
     def getStartFrame(self):
-        return self._start_frame
+        return self._startFrame
 
-    def setEndFrame(self, end_frame):
+    def setEndFrame(self, endFrame):
         if (
-            self._start_frame is not None and
-            end_frame is not None and
-            end_frame < self._start_frame
+            self._startFrame is not None and
+            endFrame is not None and
+            endFrame < self._startFrame
         ):
             raise ValueError("End frame must be greater than start frame.")
-        if end_frame is not None:
-            if int(end_frame) != end_frame:
+        if endFrame is not None:
+            if int(endFrame) != endFrame:
                 raise ValueError("Frame numbers must be integers.")
-            self._end_frame = int(end_frame)
+            self._endFrame = int(endFrame)
         else:
-            self._end_frame = None
+            self._endFrame = None
 
     def getEndFrame(self):
-        return self._end_frame
+        return self._endFrame

--- a/python/GafferDeadline/__init__.py
+++ b/python/GafferDeadline/__init__.py
@@ -39,4 +39,4 @@ from .GafferDeadlineJob import GafferDeadlineJob
 from .GafferDeadlineTask import GafferDeadlineTask
 from .DeadlineTools import *
 
-__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", {}, subdirectory = "GafferDeadline" )
+__import__("IECore").loadConfig("GAFFER_STARTUP_PATHS", {}, subdirectory="GafferDeadline")

--- a/python/GafferDeadline/__init__.py
+++ b/python/GafferDeadline/__init__.py
@@ -34,9 +34,9 @@
 #
 ##########################################################################
 
-from DeadlineDispatcher import DeadlineDispatcher
-from GafferDeadlineJob import GafferDeadlineJob
-from GafferDeadlineTask import GafferDeadlineTask
-from DeadlineTools import *
+from .DeadlineDispatcher import DeadlineDispatcher
+from .GafferDeadlineJob import GafferDeadlineJob
+from .GafferDeadlineTask import GafferDeadlineTask
+from .DeadlineTools import *
 
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", {}, subdirectory = "GafferDeadline" )

--- a/python/GafferDeadlineTest/DeadlineDispatcherTest.py
+++ b/python/GafferDeadlineTest/DeadlineDispatcherTest.py
@@ -36,12 +36,13 @@
 
 import os
 import unittest
-import mock
+from unittest import mock
 
 import Gaffer
 import GafferTest
 import GafferDispatch
 import GafferDispatchTest
+
 import GafferDeadline
 
 
@@ -383,7 +384,7 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         s = Gaffer.ScriptNode()
 
         s["n"] = GafferDispatch.PythonCommand()
-        s["n"]["command"] = Gaffer.StringPlug(defaultValue="print context.getFrame()", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n"]["command"] = Gaffer.StringPlug(defaultValue="print(context.getFrame())", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
         s["n"]["sequence"].setValue(True)
         s["n"]["dispatcher"]["batchSize"].setValue(1)
 

--- a/python/GafferDeadlineTest/DeadlineDispatcherTest.py
+++ b/python/GafferDeadlineTest/DeadlineDispatcherTest.py
@@ -394,7 +394,7 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
                     GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.none
                 )
 
-    def testOverrideJob(self):
+    def testOverrideFrame(self):
         #   n1
         #   |
         #   n2

--- a/python/GafferDeadlineTest/DeadlineDispatcherTest.py
+++ b/python/GafferDeadlineTest/DeadlineDispatcherTest.py
@@ -211,15 +211,15 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
             jobs = self.__job([s["n2"], s["n3"]])
 
         self.assertEqual(len(jobs), 3)
-        dependency_count = {"n1": 0, "n2": 1, "n3": 0}
+        dependencyCount = {"n1": 0, "n2": 1, "n3": 0}
         self.assertEqual(
-            len(jobs[0].getParentJobs()), dependency_count[jobs[0].getJobProperties()["Name"]]
+            len(jobs[0].getParentJobs()), dependencyCount[jobs[0].getJobProperties()["Name"]]
         )
         self.assertEqual(
-            len(jobs[1].getParentJobs()), dependency_count[jobs[1].getJobProperties()["Name"]]
+            len(jobs[1].getParentJobs()), dependencyCount[jobs[1].getJobProperties()["Name"]]
         )
         self.assertEqual(
-            len(jobs[2].getParentJobs()), dependency_count[jobs[2].getJobProperties()["Name"]]
+            len(jobs[2].getParentJobs()), dependencyCount[jobs[2].getJobProperties()["Name"]]
         )
 
     def testSharedPreTasks(self):
@@ -384,7 +384,7 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
                 self.assertEqual(len(j.getTasks()), 4)
                 self.assertEqual(
                     j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.job_to_job
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.jobToJob
                 )
             elif j.getJobProperties()["Name"] == "n1":
                 self.assertEqual(len(j.getDependencies()), 0)
@@ -434,7 +434,7 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
                 self.assertEqual(len(j.getTasks()), 4)
                 self.assertEqual(
                     j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frame_to_frame
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frameToFrame
                 )
             elif j.getJobProperties()["Name"] == "n1":
                 self.assertEqual(len(j.getDependencies()), 0)
@@ -785,7 +785,7 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
                 self.assertEqual(len(j.getTasks()), 4)
                 self.assertEqual(
                     j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frame_to_frame
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frameToFrame
                 )
             elif j.getJobProperties()["Name"] == "n1":
                 self.assertEqual(len(j.getDependencies()), 0)
@@ -795,21 +795,21 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
                 self.assertEqual(len(j.getTasks()), 1)
                 self.assertEqual(
                     j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frame_to_frame
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frameToFrame
                 )
             elif j.getJobProperties()["Name"] == "n4":
                 self.assertEqual(len(j.getDependencies()), 4)
                 self.assertEqual(len(j.getTasks()), 4)
                 self.assertEqual(
                     j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frame_to_frame
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frameToFrame
                 )
             elif j.getJobProperties()["Name"] == "t1":
                 self.assertEqual(len(j.getDependencies()), 12)
                 self.assertEqual(len(j.getTasks()), 5)
                 self.assertEqual(
                     j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frame_to_frame
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frameToFrame
                 )
 
     def testFrameMask(self):
@@ -857,7 +857,7 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
                 self.assertEqual(len(j.getTasks()), 50)
                 self.assertEqual(
                     j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.job_to_job
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.jobToJob
                 )
             elif j.getJobProperties()["Name"] == "n1":
                 self.assertEqual(len(j.getDependencies()), 0)
@@ -940,10 +940,10 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
                 self.assertEqual(len(j.getTasks()), 50)
                 self.assertEqual(
                     j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frame_to_frame
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frameToFrame
                 )
-                self.assertEqual(j._frame_dependency_offset_start, 100)
-                self.assertEqual(j._frame_dependency_offset_end, 100)
+                self.assertEqual(j._frameDependencyOffsetStart, 100)
+                self.assertEqual(j._frameDependencyOffsetEnd, 100)
             elif j.getJobProperties()["Name"] == "n1":
                 self.assertEqual(len(j.getDependencies()), 0)
                 self.assertEqual(len(j.getTasks()), 50)

--- a/python/GafferDeadlineTest/DeadlineDispatcherTest.py
+++ b/python/GafferDeadlineTest/DeadlineDispatcherTest.py
@@ -49,7 +49,9 @@ import GafferDeadline
 class DeadlineDispatcherTest(GafferTest.TestCase):
     def __dispatcher(self):
         dispatcher = GafferDeadline.DeadlineDispatcher()
-        dispatcher["jobsDirectory"].setValue(os.path.join(self.temporaryDirectory(), "testJobDirectory").replace("\\", "\\\\"))
+        dispatcher["jobsDirectory"].setValue(
+            os.path.join(self.temporaryDirectory(), "testJobDirectory").replace("\\", "\\\\")
+        )
 
         return dispatcher
 
@@ -80,7 +82,10 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         c = GafferDeadline.DeadlineDispatcher.preSpoolSignal().connect(f)
 
         dispatcher = self.__dispatcher()
-        with mock.patch('GafferDeadline.DeadlineTools.submitJob', return_value=("testID", "testMessage")):
+        with mock.patch(
+            "GafferDeadline.DeadlineTools.submitJob",
+            return_value=("testID", "testMessage")
+        ):
             dispatcher.dispatch([s["n"]])
 
         self.assertEqual(len(spooled), 1)
@@ -91,7 +96,10 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         s["n"] = GafferDispatchTest.LoggingTaskNode()
 
         dispatcher = self.__dispatcher()
-        with mock.patch('GafferDeadline.DeadlineTools.submitJob', return_value=("testID", "testMessage")):
+        with mock.patch(
+            "GafferDeadline.DeadlineTools.submitJob",
+            return_value=("testID", "testMessage")
+        ):
             dispatcher.dispatch([s["n"]])
 
         self.assertTrue(os.path.isfile(os.path.join(dispatcher.jobDirectory(), "n.job")))
@@ -100,14 +108,20 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
     def testTaskAttributes(self):
         s = Gaffer.ScriptNode()
         s["n"] = GafferDispatchTest.LoggingTaskNode()
-        s["n"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n"]["dispatcher"]["batchSize"].setValue(10)
 
         dispatcher = self.__dispatcher()
         dispatcher["framesMode"].setValue(dispatcher.FramesMode.CustomRange)
         dispatcher["frameRange"].setValue("1-10")
 
-        with mock.patch('GafferDeadline.DeadlineTools.submitJob', return_value=("testID", "testMessage")):
+        with mock.patch(
+            "GafferDeadline.DeadlineTools.submitJob",
+            return_value=("testID", "testMessage")
+        ):
             jobs = self.__job([s["n"]], dispatcher)
         self.assertEqual(len(jobs[0].getParentJobs()), 0)
         self.assertEqual(len(jobs[0].getTasks()), 1)
@@ -115,14 +129,20 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
     def testMultipleBatches(self):
         s = Gaffer.ScriptNode()
         s["n"] = GafferDispatchTest.LoggingTaskNode()
-        s["n"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n"]["dispatcher"]["batchSize"].setValue(1)
 
         dispatcher = self.__dispatcher()
         dispatcher["framesMode"].setValue(dispatcher.FramesMode.CustomRange)
         dispatcher["frameRange"].setValue("1-10")
 
-        with mock.patch('GafferDeadline.DeadlineTools.submitJob', return_value=("testID", "testMessage")):
+        with mock.patch(
+            "GafferDeadline.DeadlineTools.submitJob",
+            return_value=("testID", "testMessage")
+        ):
             jobs = self.__job([s["n"]], dispatcher)
 
         self.assertEqual(len(jobs), 1)
@@ -132,14 +152,20 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
     def testSingleBatch(self):
         s = Gaffer.ScriptNode()
         s["n"] = GafferDispatchTest.LoggingTaskNode()
-        s["n"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n"]["dispatcher"]["batchSize"].setValue(10)
 
         dispatcher = self.__dispatcher()
         dispatcher["framesMode"].setValue(dispatcher.FramesMode.CustomRange)
         dispatcher["frameRange"].setValue("1-10")
 
-        with mock.patch('GafferDeadline.DeadlineTools.submitJob', return_value=("testID", "testMessage")):
+        with mock.patch(
+            "GafferDeadline.DeadlineTools.submitJob",
+            return_value=("testID", "testMessage")
+        ):
             jobs = self.__job([s["n"]], dispatcher)
 
         self.assertEqual(len(jobs), 1)
@@ -148,14 +174,20 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
     def testCollapseIdenticalFrames(self):
         s = Gaffer.ScriptNode()
         s["n"] = GafferDispatch.PythonCommand()
-        s["n"]["command"] = Gaffer.StringPlug(defaultValue="print(\"Hello\")", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n"]["command"] = Gaffer.StringPlug(
+            defaultValue="print(\"Hello\")",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n"]["dispatcher"]["batchSize"].setValue(1)
 
         dispatcher = self.__dispatcher()
         dispatcher["framesMode"].setValue(dispatcher.FramesMode.CustomRange)
         dispatcher["frameRange"].setValue("1-10")
 
-        with mock.patch('GafferDeadline.DeadlineTools.submitJob', return_value=("testID", "testMessage")):
+        with mock.patch(
+            "GafferDeadline.DeadlineTools.submitJob",
+            return_value=("testID", "testMessage")
+        ):
             jobs = self.__job([s["n"]], dispatcher)
 
         self.assertEqual(len(jobs), 1)
@@ -172,14 +204,23 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         s["n3"] = GafferDispatchTest.LoggingTaskNode()
         s["n2"]["preTasks"][0].setInput(s["n1"]["task"])
 
-        with mock.patch('GafferDeadline.DeadlineTools.submitJob', return_value=("testID", "testMessage")):
+        with mock.patch(
+            "GafferDeadline.DeadlineTools.submitJob",
+            return_value=("testID", "testMessage")
+        ):
             jobs = self.__job([s["n2"], s["n3"]])
 
         self.assertEqual(len(jobs), 3)
-        dependency_count = {"n1":0, "n2": 1, "n3": 0}
-        self.assertEqual(len(jobs[0].getParentJobs()), dependency_count[jobs[0].getJobProperties()["Name"]])
-        self.assertEqual(len(jobs[1].getParentJobs()), dependency_count[jobs[1].getJobProperties()["Name"]])
-        self.assertEqual(len(jobs[2].getParentJobs()), dependency_count[jobs[2].getJobProperties()["Name"]])
+        dependency_count = {"n1": 0, "n2": 1, "n3": 0}
+        self.assertEqual(
+            len(jobs[0].getParentJobs()), dependency_count[jobs[0].getJobProperties()["Name"]]
+        )
+        self.assertEqual(
+            len(jobs[1].getParentJobs()), dependency_count[jobs[1].getJobProperties()["Name"]]
+        )
+        self.assertEqual(
+            len(jobs[2].getParentJobs()), dependency_count[jobs[2].getJobProperties()["Name"]]
+        )
 
     def testSharedPreTasks(self):
         #   n1
@@ -199,7 +240,10 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         s["n2"]["preTasks"][0].setInput(s["i1"]["task"])
         s["n2"]["preTasks"][1].setInput(s["i2"]["task"])
 
-        with mock.patch('GafferDeadline.DeadlineTools.submitJob', return_value=("testID", "testMessage")):
+        with mock.patch(
+            "GafferDeadline.DeadlineTools.submitJob",
+            return_value=("testID", "testMessage")
+        ):
             jobs = self.__job([s["n2"]])
 
         self.assertEqual(len(jobs), 4)
@@ -215,11 +259,15 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         s = Gaffer.ScriptNode()
 
         s["n1"] = GafferDispatchTest.LoggingTaskNode()
-        s["n1"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n1"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n1"]["dispatcher"]["batchSize"].setValue(10)
 
         s["n2"] = GafferDispatchTest.LoggingTaskNode()
-        s["n2"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n2"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
         s["n2"]["dispatcher"]["batchSize"].setValue(13)
         s["n2"]["preTasks"][0].setInput(s["n1"]["task"])
 
@@ -227,7 +275,10 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         dispatcher["framesMode"].setValue(dispatcher.FramesMode.CustomRange)
         dispatcher["frameRange"].setValue("1-50")
 
-        with mock.patch('GafferDeadline.DeadlineTools.submitJob', return_value=("testID", "testMessage")):
+        with mock.patch(
+            "GafferDeadline.DeadlineTools.submitJob",
+            return_value=("testID", "testMessage")
+        ):
             jobs = self.__job([s["n2"]], dispatcher)
 
         self.assertEqual(len(jobs), 2)
@@ -238,7 +289,10 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
             elif j.getJobProperties()["Name"] == "n1":
                 self.assertEqual(len(j.getDependencies()), 0)
                 self.assertEqual(len(j.getTasks()), 5)
-                self.assertEqual(j.getDependencyType(), GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.none)
+                self.assertEqual(
+                    j.getDependencyType(),
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.none
+                )
 
     def testOverrideNone(self):
         #   n1
@@ -248,11 +302,17 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         s = Gaffer.ScriptNode()
 
         s["n1"] = GafferDispatchTest.LoggingTaskNode()
-        s["n1"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n1"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n1"]["dispatcher"]["batchSize"].setValue(10)
 
         s["n2"] = GafferDispatchTest.LoggingTaskNode()
-        s["n2"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n2"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n2"]["dispatcher"]["batchSize"].setValue(13)
         s["n2"]["dispatcher"]["deadline"]["dependencyMode"].setValue("None")
         s["n2"]["preTasks"][0].setInput(s["n1"]["task"])
@@ -261,7 +321,10 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         dispatcher["framesMode"].setValue(dispatcher.FramesMode.CustomRange)
         dispatcher["frameRange"].setValue("1-50")
 
-        with mock.patch('GafferDeadline.DeadlineTools.submitJob', return_value=("testID", "testMessage")):
+        with mock.patch(
+            "GafferDeadline.DeadlineTools.submitJob",
+            return_value=("testID", "testMessage")
+        ):
             jobs = self.__job([s["n2"]], dispatcher)
 
         self.assertEqual(len(jobs), 2)
@@ -269,11 +332,17 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
             if j.getJobProperties()["Name"] == "n2":
                 self.assertEqual(len(j.getDependencies()), 8)
                 self.assertEqual(len(j.getTasks()), 4)
-                self.assertEqual(j.getDependencyType(), GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.none)
+                self.assertEqual(
+                    j.getDependencyType(),
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.none
+                )
             elif j.getJobProperties()["Name"] == "n1":
                 self.assertEqual(len(j.getDependencies()), 0)
                 self.assertEqual(len(j.getTasks()), 5)
-                self.assertEqual(j.getDependencyType(), GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.none)
+                self.assertEqual(
+                    j.getDependencyType(),
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.none
+                )
 
     def testOverrideJob(self):
         #   n1
@@ -283,11 +352,17 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         s = Gaffer.ScriptNode()
 
         s["n1"] = GafferDispatchTest.LoggingTaskNode()
-        s["n1"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n1"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n1"]["dispatcher"]["batchSize"].setValue(10)
 
         s["n2"] = GafferDispatchTest.LoggingTaskNode()
-        s["n2"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n2"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n2"]["dispatcher"]["batchSize"].setValue(13)
         s["n2"]["dispatcher"]["deadline"]["dependencyMode"].setValue("Job")
         s["n2"]["preTasks"][0].setInput(s["n1"]["task"])
@@ -296,7 +371,10 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         dispatcher["framesMode"].setValue(dispatcher.FramesMode.CustomRange)
         dispatcher["frameRange"].setValue("1-50")
 
-        with mock.patch('GafferDeadline.DeadlineTools.submitJob', return_value=("testID", "testMessage")):
+        with mock.patch(
+            "GafferDeadline.DeadlineTools.submitJob",
+            return_value=("testID", "testMessage")
+        ):
             jobs = self.__job([s["n2"]], dispatcher)
 
         self.assertEqual(len(jobs), 2)
@@ -304,11 +382,17 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
             if j.getJobProperties()["Name"] == "n2":
                 self.assertEqual(len(j.getDependencies()), 8)
                 self.assertEqual(len(j.getTasks()), 4)
-                self.assertEqual(j.getDependencyType(), GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.job_to_job)
+                self.assertEqual(
+                    j.getDependencyType(),
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.job_to_job
+                )
             elif j.getJobProperties()["Name"] == "n1":
                 self.assertEqual(len(j.getDependencies()), 0)
                 self.assertEqual(len(j.getTasks()), 5)
-                self.assertEqual(j.getDependencyType(), GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.none)
+                self.assertEqual(
+                    j.getDependencyType(),
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.none
+                )
 
     def testOverrideJob(self):
         #   n1
@@ -318,11 +402,17 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         s = Gaffer.ScriptNode()
 
         s["n1"] = GafferDispatchTest.LoggingTaskNode()
-        s["n1"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n1"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n1"]["dispatcher"]["batchSize"].setValue(10)
 
         s["n2"] = GafferDispatchTest.LoggingTaskNode()
-        s["n2"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n2"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n2"]["dispatcher"]["batchSize"].setValue(13)
         s["n2"]["dispatcher"]["deadline"]["dependencyMode"].setValue("Frame")
         s["n2"]["preTasks"][0].setInput(s["n1"]["task"])
@@ -331,7 +421,10 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         dispatcher["framesMode"].setValue(dispatcher.FramesMode.CustomRange)
         dispatcher["frameRange"].setValue("1-50")
 
-        with mock.patch('GafferDeadline.DeadlineTools.submitJob', return_value=("testID", "testMessage")):
+        with mock.patch(
+            "GafferDeadline.DeadlineTools.submitJob",
+            return_value=("testID", "testMessage")
+        ):
             jobs = self.__job([s["n2"]], dispatcher)
 
         self.assertEqual(len(jobs), 2)
@@ -339,11 +432,17 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
             if j.getJobProperties()["Name"] == "n2":
                 self.assertEqual(len(j.getDependencies()), 8)
                 self.assertEqual(len(j.getTasks()), 4)
-                self.assertEqual(j.getDependencyType(), GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frame_to_frame)
+                self.assertEqual(
+                    j.getDependencyType(),
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frame_to_frame
+                )
             elif j.getJobProperties()["Name"] == "n1":
                 self.assertEqual(len(j.getDependencies()), 0)
                 self.assertEqual(len(j.getTasks()), 5)
-                self.assertEqual(j.getDependencyType(), GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.none)
+                self.assertEqual(
+                    j.getDependencyType(),
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.none
+                )
 
     def testOverrideScript(self):
         #   n1
@@ -353,11 +452,17 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         s = Gaffer.ScriptNode()
 
         s["n1"] = GafferDispatchTest.LoggingTaskNode()
-        s["n1"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n1"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n1"]["dispatcher"]["batchSize"].setValue(10)
 
         s["n2"] = GafferDispatchTest.LoggingTaskNode()
-        s["n2"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n2"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n2"]["dispatcher"]["batchSize"].setValue(13)
         s["n2"]["dispatcher"]["deadline"]["dependencyMode"].setValue("Script")
         s["n2"]["preTasks"][0].setInput(s["n1"]["task"])
@@ -366,7 +471,10 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         dispatcher["framesMode"].setValue(dispatcher.FramesMode.CustomRange)
         dispatcher["frameRange"].setValue("1-50")
 
-        with mock.patch('GafferDeadline.DeadlineTools.submitJob', return_value=("testID", "testMessage")):
+        with mock.patch(
+            "GafferDeadline.DeadlineTools.submitJob",
+            return_value=("testID", "testMessage")
+        ):
             jobs = self.__job([s["n2"]], dispatcher)
 
         self.assertEqual(len(jobs), 2)
@@ -374,17 +482,26 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
             if j.getJobProperties()["Name"] == "n2":
                 self.assertEqual(len(j.getDependencies()), 8)
                 self.assertEqual(len(j.getTasks()), 4)
-                self.assertEqual(j.getDependencyType(), GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.scripted)
+                self.assertEqual(
+                    j.getDependencyType(),
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.scripted
+                )
             elif j.getJobProperties()["Name"] == "n1":
                 self.assertEqual(len(j.getDependencies()), 0)
                 self.assertEqual(len(j.getTasks()), 5)
-                self.assertEqual(j.getDependencyType(), GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.none)
+                self.assertEqual(
+                    j.getDependencyType(),
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.none
+                )
 
     def testSequence(self):
         s = Gaffer.ScriptNode()
 
         s["n"] = GafferDispatch.PythonCommand()
-        s["n"]["command"] = Gaffer.StringPlug(defaultValue="print(context.getFrame())", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n"]["command"] = Gaffer.StringPlug(
+            defaultValue="print(context.getFrame())",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n"]["sequence"].setValue(True)
         s["n"]["dispatcher"]["batchSize"].setValue(1)
 
@@ -392,7 +509,10 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         dispatcher["framesMode"].setValue(dispatcher.FramesMode.CustomRange)
         dispatcher["frameRange"].setValue("1-50")
 
-        with mock.patch('GafferDeadline.DeadlineTools.submitJob', return_value=("testID", "testMessage")):
+        with mock.patch(
+            "GafferDeadline.DeadlineTools.submitJob",
+            return_value=("testID", "testMessage")
+        ):
             jobs = self.__job([s["n"]], dispatcher)
 
         self.assertEqual(len(jobs), 1)
@@ -411,11 +531,17 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         s = Gaffer.ScriptNode()
 
         s["n1"] = GafferDispatchTest.LoggingTaskNode()
-        s["n1"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n1"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n1"]["dispatcher"]["batchSize"].setValue(10)
 
         s["n2"] = GafferDispatchTest.LoggingTaskNode()
-        s["n2"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n2"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n2"]["dispatcher"]["batchSize"].setValue(13)
 
         s["d1"] = Gaffer.Dot()
@@ -427,7 +553,10 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         dispatcher["framesMode"].setValue(dispatcher.FramesMode.CustomRange)
         dispatcher["frameRange"].setValue("1-50")
 
-        with mock.patch('GafferDeadline.DeadlineTools.submitJob', return_value=("testID", "testMessage")):
+        with mock.patch(
+            "GafferDeadline.DeadlineTools.submitJob",
+            return_value=("testID", "testMessage")
+        ):
             jobs = self.__job([s["n2"]], dispatcher)
 
         self.assertEqual(len(jobs), 2)
@@ -438,7 +567,10 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
             elif j.getJobProperties()["Name"] == "n1":
                 self.assertEqual(len(j.getDependencies()), 0)
                 self.assertEqual(len(j.getTasks()), 5)
-                self.assertEqual(j.getDependencyType(), GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.none)
+                self.assertEqual(
+                    j.getDependencyType(),
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.none
+                )
 
     def testDependencies(self):
         #   n1
@@ -450,21 +582,33 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         s = Gaffer.ScriptNode()
 
         s["n1"] = GafferDispatchTest.LoggingTaskNode()
-        s["n1"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n1"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n1"]["dispatcher"]["batchSize"].setValue(10)
 
         s["i1"] = GafferDispatchTest.LoggingTaskNode()
-        s["i1"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["i1"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["i1"]["dispatcher"]["batchSize"].setValue(25)
         s["i1"]["preTasks"][0].setInput(s["n1"]["task"])
 
         s["i2"] = GafferDispatchTest.LoggingTaskNode()
-        s["i2"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["i2"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["i2"]["dispatcher"]["batchSize"].setValue(1)
         s["i2"]["preTasks"][0].setInput(s["n1"]["task"])
 
         s["n2"] = GafferDispatchTest.LoggingTaskNode()
-        s["n2"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n2"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n2"]["dispatcher"]["batchSize"].setValue(13)
         s["n2"]["preTasks"][0].setInput(s["i1"]["task"])
         s["n2"]["preTasks"][1].setInput(s["i2"]["task"])
@@ -473,7 +617,10 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         dispatcher["framesMode"].setValue(dispatcher.FramesMode.CustomRange)
         dispatcher["frameRange"].setValue("1-50")
 
-        with mock.patch('GafferDeadline.DeadlineTools.submitJob', return_value=("testID", "testMessage")):
+        with mock.patch(
+            "GafferDeadline.DeadlineTools.submitJob",
+            return_value=("testID", "testMessage")
+        ):
             jobs = self.__job([s["n2"]], dispatcher)
 
         self.assertEqual(len(jobs), 4)
@@ -504,20 +651,32 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         s = Gaffer.ScriptNode()
 
         s["n1"] = GafferDispatchTest.LoggingTaskNode()
-        s["n1"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n1"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n1"]["dispatcher"]["batchSize"].setValue(10)
 
         s["n2"] = GafferDispatchTest.LoggingTaskNode()
-        s["n2"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n2"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n2"]["dispatcher"]["batchSize"].setValue(25)
         s["n2"]["preTasks"][0].setInput(s["n1"]["task"])
 
         s["n3"] = GafferDispatchTest.LoggingTaskNode()
-        s["n3"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n3"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n3"]["dispatcher"]["batchSize"].setValue(1)
 
         s["n4"] = GafferDispatchTest.LoggingTaskNode()
-        s["n4"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n4"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n4"]["dispatcher"]["batchSize"].setValue(1)
 
         s["t1"] = GafferDispatch.TaskList()
@@ -534,7 +693,10 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         dispatcher["framesMode"].setValue(dispatcher.FramesMode.CustomRange)
         dispatcher["frameRange"].setValue("1-50")
 
-        with mock.patch('GafferDeadline.DeadlineTools.submitJob', return_value=("testID", "testMessage")):
+        with mock.patch(
+            "GafferDeadline.DeadlineTools.submitJob",
+            return_value=("testID", "testMessage")
+        ):
             jobs = self.__job([s["t2"]], dispatcher)
 
         self.assertEqual(len(jobs), 6)
@@ -571,21 +733,33 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         s = Gaffer.ScriptNode()
 
         s["n1"] = GafferDispatchTest.LoggingTaskNode()
-        s["n1"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n1"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n1"]["dispatcher"]["batchSize"].setValue(1)
 
         s["n2"] = GafferDispatchTest.LoggingTaskNode()
-        s["n2"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n2"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n2"]["dispatcher"]["batchSize"].setValue(15)
         s["n2"]["preTasks"][0].setInput(s["n1"]["task"])
 
         s["n3"] = GafferDispatchTest.LoggingTaskNode()
-        s["n3"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n3"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n3"]["dispatcher"]["batchSize"].setValue(50)
         s["n3"]["preTasks"][0].setInput(s["n1"]["task"])
 
         s["n4"] = GafferDispatchTest.LoggingTaskNode()
-        s["n4"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n4"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n4"]["dispatcher"]["batchSize"].setValue(15)
         s["n4"]["preTasks"][0].setInput(s["n2"]["task"])
 
@@ -593,13 +767,15 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         s["t1"]["dispatcher"]["batchSize"].setValue(10)
         s["t1"]["preTasks"][0].setInput(s["n4"]["task"])
         s["t1"]["preTasks"][1].setInput(s["n3"]["task"])
-        
 
         dispatcher = self.__dispatcher()
         dispatcher["framesMode"].setValue(dispatcher.FramesMode.CustomRange)
         dispatcher["frameRange"].setValue("1-50")
 
-        with mock.patch('GafferDeadline.DeadlineTools.submitJob', return_value=("testID", "testMessage")):
+        with mock.patch(
+            "GafferDeadline.DeadlineTools.submitJob",
+            return_value=("testID", "testMessage")
+        ):
             jobs = self.__job([s["t1"]], dispatcher)
 
         self.assertEqual(len(jobs), 5)
@@ -607,33 +783,48 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
             if j.getJobProperties()["Name"] == "n2":
                 self.assertEqual(len(j.getDependencies()), 50)
                 self.assertEqual(len(j.getTasks()), 4)
-                self.assertEqual(j.getDependencyType(), GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frame_to_frame)
+                self.assertEqual(
+                    j.getDependencyType(),
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frame_to_frame
+                )
             elif j.getJobProperties()["Name"] == "n1":
                 self.assertEqual(len(j.getDependencies()), 0)
                 self.assertEqual(len(j.getTasks()), 50)
             elif j.getJobProperties()["Name"] == "n3":
                 self.assertEqual(len(j.getDependencies()), 50)
                 self.assertEqual(len(j.getTasks()), 1)
-                self.assertEqual(j.getDependencyType(), GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frame_to_frame)
+                self.assertEqual(
+                    j.getDependencyType(),
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frame_to_frame
+                )
             elif j.getJobProperties()["Name"] == "n4":
                 self.assertEqual(len(j.getDependencies()), 4)
                 self.assertEqual(len(j.getTasks()), 4)
-                self.assertEqual(j.getDependencyType(), GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frame_to_frame)
+                self.assertEqual(
+                    j.getDependencyType(),
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frame_to_frame
+                )
             elif j.getJobProperties()["Name"] == "t1":
                 self.assertEqual(len(j.getDependencies()), 12)
                 self.assertEqual(len(j.getTasks()), 5)
-                self.assertEqual(j.getDependencyType(), GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frame_to_frame)
+                self.assertEqual(
+                    j.getDependencyType(),
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frame_to_frame
+                )
 
     def testFrameMask(self):
         #   n1
         #   |
         #   m1
         #   |
-        #   n2 
+        #   n2
         s = Gaffer.ScriptNode()
 
         s["n1"] = GafferDispatchTest.LoggingTaskNode()
-        s["n1"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n1"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n1"]["dispatcher"]["batchSize"].setValue(1)
 
         s["m1"] = GafferDispatch.FrameMask()
@@ -642,7 +833,10 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         s["m1"]["preTasks"][0].setInput(s["n1"]["task"])
 
         s["n2"] = GafferDispatchTest.LoggingTaskNode()
-        s["n2"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n2"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n2"]["dispatcher"]["batchSize"].setValue(1)
         s["n2"]["preTasks"][0].setInput(s["m1"]["task"])
 
@@ -650,7 +844,10 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         dispatcher["framesMode"].setValue(dispatcher.FramesMode.CustomRange)
         dispatcher["frameRange"].setValue("1-50")
 
-        with mock.patch('GafferDeadline.DeadlineTools.submitJob', return_value=("testID", "testMessage")):
+        with mock.patch(
+            "GafferDeadline.DeadlineTools.submitJob",
+            return_value=("testID", "testMessage")
+        ):
             jobs = self.__job([s["n2"]], dispatcher)
 
         self.assertEqual(len(jobs), 3)
@@ -658,7 +855,10 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
             if j.getJobProperties()["Name"] == "n2":
                 self.assertEqual(len(j.getDependencies()), 50)
                 self.assertEqual(len(j.getTasks()), 50)
-                self.assertEqual(j.getDependencyType(), GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.job_to_job)
+                self.assertEqual(
+                    j.getDependencyType(),
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.job_to_job
+                )
             elif j.getJobProperties()["Name"] == "n1":
                 self.assertEqual(len(j.getDependencies()), 0)
                 self.assertEqual(len(j.getTasks()), 5)
@@ -668,27 +868,58 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         #   |
         #   c1 ---- e1
         #   |
-        #   n2 
+        #   n2
         s = Gaffer.ScriptNode()
 
         s["n1"] = GafferDispatchTest.LoggingTaskNode()
-        s["n1"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n1"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n1"]["dispatcher"]["batchSize"].setValue(1)
 
         s["c1"] = GafferDispatch.TaskContextVariables()
-        s["c1"]["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "member1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
-        s["c1"]["variables"]["member1"].addChild( Gaffer.StringPlug( "name", defaultValue = '', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
-        s["c1"]["variables"]["member1"].addChild( Gaffer.FloatPlug( "value", defaultValue = 0.0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
-        s["c1"]["variables"]["member1"].addChild( Gaffer.BoolPlug( "enabled", defaultValue = True, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
-        s["c1"]["variables"]["member1"]["name"].setValue( 'frame' )
+        s["c1"]["variables"].addChild(
+            Gaffer.CompoundDataPlug.MemberPlug(
+                "member1", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic,
+            )
+        )
+        s["c1"]["variables"]["member1"].addChild(
+            Gaffer.StringPlug(
+                "name",
+                defaultValue='',
+                flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic,
+            )
+        )
+        s["c1"]["variables"]["member1"].addChild(
+            Gaffer.FloatPlug(
+                "value",
+                defaultValue=0.0,
+                flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic,
+            )
+        )
+        s["c1"]["variables"]["member1"].addChild(
+            Gaffer.BoolPlug(
+                "enabled",
+                defaultValue=True,
+                flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic,
+            )
+        )
+        s["c1"]["variables"]["member1"]["name"].setValue('frame')
         s["c1"]["dispatcher"]["batchSize"].setValue(1)
         s["c1"]["preTasks"][0].setInput(s["n1"]["task"])
 
         s["e"] = Gaffer.Expression()
-        s["e"].setExpression( 'parent["c1"]["variables"]["member1"]["value"] = context.getFrame() + 100', "python")
+        s["e"].setExpression(
+            'parent["c1"]["variables"]["member1"]["value"] = context.getFrame() + 100',
+            "python"
+        )
 
         s["n2"] = GafferDispatchTest.LoggingTaskNode()
-        s["n2"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n2"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n2"]["dispatcher"]["batchSize"].setValue(1)
         s["n2"]["preTasks"][0].setInput(s["c1"]["task"])
 
@@ -696,7 +927,10 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         dispatcher["framesMode"].setValue(dispatcher.FramesMode.CustomRange)
         dispatcher["frameRange"].setValue("1-50")
 
-        with mock.patch('GafferDeadline.DeadlineTools.submitJob', return_value=("testID", "testMessage")):
+        with mock.patch(
+            "GafferDeadline.DeadlineTools.submitJob",
+            return_value=("testID", "testMessage")
+        ):
             jobs = self.__job([s["n2"]], dispatcher)
 
         self.assertEqual(len(jobs), 3)
@@ -704,39 +938,74 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
             if j.getJobProperties()["Name"] == "n2":
                 self.assertEqual(len(j.getDependencies()), 50)
                 self.assertEqual(len(j.getTasks()), 50)
-                self.assertEqual(j.getDependencyType(), GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frame_to_frame)
+                self.assertEqual(
+                    j.getDependencyType(),
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frame_to_frame
+                )
                 self.assertEqual(j._frame_dependency_offset_start, 100)
                 self.assertEqual(j._frame_dependency_offset_end, 100)
             elif j.getJobProperties()["Name"] == "n1":
                 self.assertEqual(len(j.getDependencies()), 0)
                 self.assertEqual(len(j.getTasks()), 50)
-    
+
     def testScriptFrameDependency(self):
         #   n1
         #   |
         #   c1 ---- e1
         #   |
-        #   n2 
+        #   n2
         s = Gaffer.ScriptNode()
 
         s["n1"] = GafferDispatchTest.LoggingTaskNode()
-        s["n1"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n1"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n1"]["dispatcher"]["batchSize"].setValue(1)
 
         s["c1"] = GafferDispatch.TaskContextVariables()
-        s["c1"]["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "member1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
-        s["c1"]["variables"]["member1"].addChild( Gaffer.StringPlug( "name", defaultValue = '', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
-        s["c1"]["variables"]["member1"].addChild( Gaffer.FloatPlug( "value", defaultValue = 0.0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
-        s["c1"]["variables"]["member1"].addChild( Gaffer.BoolPlug( "enabled", defaultValue = True, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
-        s["c1"]["variables"]["member1"]["name"].setValue( 'frame' )
+        s["c1"]["variables"].addChild(
+            Gaffer.CompoundDataPlug.MemberPlug(
+                "member1",
+                flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic,
+            )
+        )
+        s["c1"]["variables"]["member1"].addChild(
+            Gaffer.StringPlug(
+                "name", defaultValue='',
+                flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic,
+            )
+        )
+        s["c1"]["variables"]["member1"].addChild(
+            Gaffer.FloatPlug(
+                "value",
+                defaultValue=0.0,
+                flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic,
+            )
+        )
+        s["c1"]["variables"]["member1"].addChild(
+            Gaffer.BoolPlug(
+                "enabled",
+                defaultValue=True,
+                flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic,
+            )
+        )
+        s["c1"]["variables"]["member1"]["name"].setValue('frame')
         s["c1"]["dispatcher"]["batchSize"].setValue(1)
         s["c1"]["preTasks"][0].setInput(s["n1"]["task"])
 
         s["e"] = Gaffer.Expression()
-        s["e"].setExpression( 'import random\nrandom.seed=(context.getFrame())\nparent["c1"]["variables"]["member1"]["value"] = random.randint(1,100000)', "python")
+        s["e"].setExpression(
+            'import random\nrandom.seed=(context.getFrame())\nparent["c1"]["variables"]["member1"]'
+            '["value"] = random.randint(1,100000)',
+            "python"
+        )
 
         s["n2"] = GafferDispatchTest.LoggingTaskNode()
-        s["n2"]["frame"] = Gaffer.StringPlug(defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
+        s["n2"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
         s["n2"]["dispatcher"]["batchSize"].setValue(1)
         s["n2"]["preTasks"][0].setInput(s["c1"]["task"])
 
@@ -744,7 +1013,10 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         dispatcher["framesMode"].setValue(dispatcher.FramesMode.CustomRange)
         dispatcher["frameRange"].setValue("1-50")
 
-        with mock.patch('GafferDeadline.DeadlineTools.submitJob', return_value=("testID", "testMessage")):
+        with mock.patch(
+            'GafferDeadline.DeadlineTools.submitJob',
+            return_value=("testID", "testMessage")
+        ):
             jobs = self.__job([s["n2"]], dispatcher)
 
         self.assertEqual(len(jobs), 3)
@@ -752,11 +1024,14 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
             if j.getJobProperties()["Name"] == "n2":
                 self.assertEqual(len(j.getDependencies()), 50)
                 self.assertEqual(len(j.getTasks()), 50)
-                self.assertEqual(j.getDependencyType(), GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.scripted)
+                self.assertEqual(
+                    j.getDependencyType(),
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.scripted
+                )
             elif j.getJobProperties()["Name"] == "n1":
                 self.assertEqual(len(j.getDependencies()), 0)
                 self.assertEqual(len(j.getTasks()), 50)
-        
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/GafferDeadlineTest/GafferDeadlineJobTest.py
+++ b/python/GafferDeadlineTest/GafferDeadlineJobTest.py
@@ -52,7 +52,7 @@ class GafferDeadlineJobTest(GafferTest.TestCase):
         self.assertIn("testProp", dj.getJobProperties())
         self.assertEqual(dj.getJobProperties()["testProp"], "testVal")
 
-        dj = GafferDeadline.GafferDeadlineJob(job_properties={"testProp2": "testVal2"})
+        dj = GafferDeadline.GafferDeadlineJob(jobProperties={"testProp2": "testVal2"})
         self.assertIn("Plugin", dj.getJobProperties())
         self.assertIn("testProp2", dj.getJobProperties())
         self.assertEqual(dj.getJobProperties()["testProp2"], "testVal2")
@@ -64,7 +64,7 @@ class GafferDeadlineJobTest(GafferTest.TestCase):
         self.assertIn("testProp", dj.getPluginProperties())
         self.assertEqual(dj.getPluginProperties()["testProp"], "testVal")
 
-        dj = GafferDeadline.GafferDeadlineJob(plugin_properties={"testProp2": "testVal2"})
+        dj = GafferDeadline.GafferDeadlineJob(pluginProperties={"testProp2": "testVal2"})
         self.assertIn("testProp2", dj.getPluginProperties())
         self.assertEqual(dj.getPluginProperties()["testProp2"], "testVal2")
 
@@ -75,18 +75,18 @@ class GafferDeadlineJobTest(GafferTest.TestCase):
         self.assertEqual(len(dj.getAuxFiles()), 2)
         self.assertIn("file1", dj.getAuxFiles())
 
-        dj = GafferDeadline.GafferDeadlineJob(aux_files=["file3", "file4"])
+        dj = GafferDeadline.GafferDeadlineJob(auxFiles=["file3", "file4"])
         self.assertEqual(len(dj.getAuxFiles()), 2)
         self.assertIn("file3", dj.getAuxFiles())
 
     def testGafferNode(self):
-        task_node = GafferDispatch.TaskNode()
+        taskNode = GafferDispatch.TaskNode()
         dj = GafferDeadline.GafferDeadlineJob()
-        dj.setGafferNode(task_node)
-        self.assertEqual(dj.getGafferNode(), task_node)
+        dj.setGafferNode(taskNode)
+        self.assertEqual(dj.getGafferNode(), taskNode)
 
-        dj = GafferDeadline.GafferDeadlineJob(gaffer_node=task_node)
-        self.assertEqual(dj.getGafferNode(), task_node)
+        dj = GafferDeadline.GafferDeadlineJob(gafferNode=taskNode)
+        self.assertEqual(dj.getGafferNode(), taskNode)
 
         self.assertRaises(ValueError, dj.setGafferNode, "bad value")
 
@@ -121,13 +121,13 @@ class GafferDeadlineJobTest(GafferTest.TestCase):
     def testParentJob(self):
         djc = GafferDeadline.GafferDeadlineJob()
         djp = GafferDeadline.GafferDeadlineJob()
-        task_node = GafferDispatch.TaskNode()
-        task_node2 = GafferDispatch.TaskNode()
+        taskNode = GafferDispatch.TaskNode()
+        taskNode2 = GafferDispatch.TaskNode()
         djc.addParentJob(djp)
         self.assertIn(djp, djc.getParentJobs())
-        djp.setGafferNode(task_node)
-        self.assertEqual(djc.getParentJobByGafferNode(task_node), djp)
-        self.assertEqual(djc.getParentJobByGafferNode(task_node2), None)
+        djp.setGafferNode(taskNode)
+        self.assertEqual(djc.getParentJobByGafferNode(taskNode), djp)
+        self.assertEqual(djc.getParentJobByGafferNode(taskNode2), None)
 
 
 if __name__ == "__main__":

--- a/python/GafferDeadlineTest/GafferDeadlineTaskTest.py
+++ b/python/GafferDeadlineTest/GafferDeadlineTaskTest.py
@@ -45,7 +45,10 @@ import GafferDispatch
 
 class GafferDeadlineTaskTest(GafferTest.TestCase):
     def testSetFrameRange(self):
-        self.assertRaises(ValueError, GafferDeadline.GafferDeadlineTask, None, 1, start_frame=1, end_frame=0)
+        self.assertRaises(
+            ValueError,
+            GafferDeadline.GafferDeadlineTask, None, 1, start_frame=1, end_frame=0
+        )
         dt = GafferDeadline.GafferDeadlineTask(None, 1, start_frame=0, end_frame=1)
         self.assertRaises(ValueError, dt.setFrameRange, 1, 0)
         self.assertRaises(ValueError, dt.setFrameRange, 0.1, 100)

--- a/python/GafferDeadlineTest/GafferDeadlineTaskTest.py
+++ b/python/GafferDeadlineTest/GafferDeadlineTaskTest.py
@@ -47,9 +47,9 @@ class GafferDeadlineTaskTest(GafferTest.TestCase):
     def testSetFrameRange(self):
         self.assertRaises(
             ValueError,
-            GafferDeadline.GafferDeadlineTask, None, 1, start_frame=1, end_frame=0
+            GafferDeadline.GafferDeadlineTask, None, 1, startFrame=1, endFrame=0
         )
-        dt = GafferDeadline.GafferDeadlineTask(None, 1, start_frame=0, end_frame=1)
+        dt = GafferDeadline.GafferDeadlineTask(None, 1, startFrame=0, endFrame=1)
         self.assertRaises(ValueError, dt.setFrameRange, 1, 0)
         self.assertRaises(ValueError, dt.setFrameRange, 0.1, 100)
         self.assertRaises(ValueError, dt.setFrameRange, 0, 100.1)

--- a/python/GafferDeadlineTest/__init__.py
+++ b/python/GafferDeadlineTest/__init__.py
@@ -36,8 +36,8 @@
 
 import unittest
 
-from DeadlineDispatcherTest import DeadlineDispatcherTest
-from GafferDeadlineJobTest import GafferDeadlineJobTest
+from .DeadlineDispatcherTest import DeadlineDispatcherTest
+from .GafferDeadlineJobTest import GafferDeadlineJobTest
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/GafferDeadlineUI/DeadlineDispatcherUI.py
+++ b/python/GafferDeadlineUI/DeadlineDispatcherUI.py
@@ -120,40 +120,46 @@ Gaffer.Metadata.registerNode(
         "dispatcher.deadline.priority": [
             "description",
             """
-            A job can have a numeric priority ranging from 0 to 100, where 0 is the lowest priority and 100 is the highest.
+            A job can have a numeric priority ranging from 0 to 100, where 0 is the lowest
+            priority and 100 is the highest.
             """,
         ],
         "dispatcher.deadline.taskTimeout": [
             "description",
             """
-            The number of minutes a slave has to render a task for this job before it requeues it. Specify 0 for no timeout.
+            The number of minutes a slave has to render a task for this job before it requeues it.
+            Specify 0 for no timeout.
             """,
         ],
         "dispatcher.deadline.enableAutoTimeout": [
             "description",
             """
-            If the Auto Task Timeout is properly configured in the repository options then enabling this will allow a task timeout
-            to be automatically calculated based on render times for previous frames of the job.
+            If the Auto Task Timeout is properly configured in the repository options then
+            enabling this will allow a task timeout to be automatically calculated based on render
+            times for previous frames of the job.
             """,
         ],
         "dispatcher.deadline.concurrentTasks": [
             "description",
             """
-            The number of tasks that can render concurrently on a single Slave. This is useful if the rendering application only
+            The number of tasks that can render concurrently on a single Slave. This is useful if
+            the rendering application only
             uses one thread to render and your Slaves have multiple CPUs.
             """,
         ],
         "dispatcher.deadline.limitToSlaveLimit": [
             "description",
             """
-            If you limit the tasks to a Slave's task limit, then by default, the Slave won't dequeue more tasks then it has CPUs.
+            If you limit the tasks to a Slave's task limit, then by default, the Slave won't
+            dequeue more tasks then it has CPUs.
             This task limit can be overridden for individual Slaves by an administrator.
             """,
         ],
         "dispatcher.deadline.machineLimit": [
             "description",
             """
-            Use the Machine Limit to specify the maximum number of machines that can render your job at one time.
+            Use the Machine Limit to specify the maximum number of machines that can render your
+            job at one time.
             Specify 0 for no limit.
             """,
         ],
@@ -206,8 +212,9 @@ Gaffer.Metadata.registerNode(
         "dispatcher.deadline.dependencyMode": [
             "description",
             """
-            Determine how downstream nodes that depend on this node will be handled. If set to auto, 
-            the dispatcher will attempt to determine the best mode, falling back to scripted dependency checking.
+            Determine how downstream nodes that depend on this node will be handled. If set to
+            auto, the dispatcher will attempt to determine the best mode, falling back to scripted
+            dependency checking.
             """,
             "preset:Auto", "Auto",
             "preset:Full Job", "Job",
@@ -222,21 +229,21 @@ Gaffer.Metadata.registerNode(
         "dispatcher.deadline.auxFiles": [
             "description",
             """
-            A list of additional files to be included with the Deadline submission as auxiliary files.
-            The submitter will upload them to the Deadline repository and Workers will download the files
-            to their local job directory. An environment variable AUXFILEDIRECTORY is set by Deadline
-            and can be referenced in Gaffer scripts using standard environment variable substitution such as
-            ${AUXFILEDIRECTORY}/file.exr
+            A list of additional files to be included with the Deadline submission as auxiliary
+            files. The submitter will upload them to the Deadline repository and Workers will
+            download the files to their local job directory. An environment variable
+            AUXFILEDIRECTORY is set by Deadline and can be referenced in Gaffer scripts using
+            standard environment variable substitution such as ${AUXFILEDIRECTORY}/file.exr
             """,
             "plugValueWidget:type", "GafferUI.FileSystemPathVectorDataPlugValueWidget",
         ],
         "dispatcher.deadline.deadlineSettings": [
             "description",
             """
-            A list of additional Deadline settings for the dispatched job. These variables are set after
-            all other settings. Adding a variable here of "Name", for example, will override the default
-            job name. A list of available settings can be found on the Manual Submission page of the
-            Deadline documentation.
+            A list of additional Deadline settings for the dispatched job. These variables are set
+            after all other settings. Adding a variable here of "Name", for example, will override
+            the default job name. A list of available settings can be found on the Manual
+            Submission page of the Deadline documentation.
             """,
             "layout:section", "Deadline Settings",
         ],

--- a/python/GafferDeadlineUI/DeadlineListPlugValueWidget.py
+++ b/python/GafferDeadlineUI/DeadlineListPlugValueWidget.py
@@ -47,7 +47,10 @@ class DeadlineListPlugValueWidget(GafferUI.PlugValueWidget):
     def __init__(self, plug, listString="", **kw):
         assert(type(listString) == str)
 
-        self.__row = GafferUI.ListContainer(GafferUI.ListContainer.Orientation.Horizontal, spacing=4)
+        self.__row = GafferUI.ListContainer(
+            GafferUI.ListContainer.Orientation.Horizontal,
+            spacing=4
+        )
         GafferUI.PlugValueWidget.__init__(self, self.__row, plug, **kw)
 
         self.__listString = listString
@@ -57,10 +60,14 @@ class DeadlineListPlugValueWidget(GafferUI.PlugValueWidget):
         self.__row.append(listWidget)
 
         button = GafferUI.Button("...", hasFrame=True)
-        self.__buttonClickedConnection = button.clickedSignal().connect(Gaffer.WeakMethod(self.__buttonClicked))
+        self.__buttonClickedConnection = button.clickedSignal().connect(
+            Gaffer.WeakMethod(self.__buttonClicked)
+        )
         self.__row.append(button)
 
-        self.__editingFinishedConnection = listWidget.editingFinishedSignal().connect(Gaffer.WeakMethod(self.__setPlugValue))
+        self.__editingFinishedConnection = listWidget.editingFinishedSignal().connect(
+            Gaffer.WeakMethod(self.__setPlugValue)
+        )
 
         self._updateFromPlug()
 
@@ -71,7 +78,10 @@ class DeadlineListPlugValueWidget(GafferUI.PlugValueWidget):
         # Get info from the farm.
         # Keep this in the button code to prevent it from being called repeatedly by Gaffer with
         # every node with a Deadline submitter attached
-        multiSelect = Gaffer.Metadata.value(self.getPlug(), "deadlineListPlugValueWidget:multiSelect")
+        multiSelect = Gaffer.Metadata.value(
+            self.getPlug(),
+            "deadlineListPlugValueWidget:multiSelect"
+        )
         if Gaffer.Metadata.value(self.getPlug(), "deadlineListPlugValueWidget:type") == "pools":
             deadlineListString = ",".join(DeadlineTools.getPools())
             dialogTitle = "Select Pools"
@@ -87,7 +97,12 @@ class DeadlineListPlugValueWidget(GafferUI.PlugValueWidget):
 
         optionListString = deadlineListString.split(",")
         selectionString = self.getPlug().getValue().split(",")
-        dialogue = GafferDeadlineUI.ListSelectionDialog(optionListString, selectionString, dialogTitle, allowMultipleSelection=multiSelect)
+        dialogue = GafferDeadlineUI.ListSelectionDialog(
+            optionListString,
+            selectionString,
+            dialogTitle,
+            allowMultipleSelection=multiSelect
+        )
         listString = dialogue.waitForSelection(parentWindow=self.ancestor(GafferUI.Window))
 
         if listString is not None:

--- a/python/GafferDeadlineUI/ListSelectionDialog.py
+++ b/python/GafferDeadlineUI/ListSelectionDialog.py
@@ -40,12 +40,22 @@ import GafferDeadlineUI
 
 
 class ListSelectionDialog(GafferUI.Dialogue):
-    def __init__(self, masterList, selectionList, title="Choose Wisely", cancelLabel="Cancel", confirmLabel="OK", allowMultipleSelection=False, **kw):
+    def __init__(
+        self,
+        masterList,
+        selectionList,
+        title="Choose Wisely",
+        cancelLabel="Cancel",
+        confirmLabel="OK",
+        allowMultipleSelection=False, **kw
+    ):
         GafferUI.Dialogue.__init__(self, title, **kw)
         self.__masterList = masterList
         self.__selectionList = [i for i in selectionList if i in masterList]
 
-        self.__masterListWidget = GafferDeadlineUI.ListWidget(allowMultipleSelection=allowMultipleSelection)
+        self.__masterListWidget = GafferDeadlineUI.ListWidget(
+            allowMultipleSelection=allowMultipleSelection
+        )
         for i in self.__masterList:
             self.__masterListWidget.addItem(i)
         self.__masterListWidget.setSelectedStrings(self.__selectionList)
@@ -53,9 +63,13 @@ class ListSelectionDialog(GafferUI.Dialogue):
         self._setWidget(self.__masterListWidget)
 
         self.__cancelButton = self._addButton(cancelLabel)
-        self.__cancelButtonConnection = self.__cancelButton.clickedSignal().connect(Gaffer.WeakMethod(self.__buttonClicked))
+        self.__cancelButtonConnection = self.__cancelButton.clickedSignal().connect(
+            Gaffer.WeakMethod(self.__buttonClicked)
+        )
         self.__confirmButton = self._addButton(confirmLabel)
-        self.__confirmButtonConnection = self.__confirmButton.clickedSignal().connect(Gaffer.WeakMethod(self.__buttonClicked))
+        self.__confirmButtonConnection = self.__confirmButton.clickedSignal().connect(
+            Gaffer.WeakMethod(self.__buttonClicked)
+        )
 
     def waitForSelection(self, **kw):
         button = self.waitForButton(**kw)

--- a/python/GafferDeadlineUI/__init__.py
+++ b/python/GafferDeadlineUI/__init__.py
@@ -34,9 +34,9 @@
 #
 ##########################################################################
 
-import DeadlineDispatcherUI
-from ListWidget import ListWidget
-from DeadlineListPlugValueWidget import DeadlineListPlugValueWidget
-from ListSelectionDialog import ListSelectionDialog
+from . import DeadlineDispatcherUI
+from .ListWidget import ListWidget
+from .DeadlineListPlugValueWidget import DeadlineListPlugValueWidget
+from .ListSelectionDialog import ListSelectionDialog
 
 __import__("IECore").loadConfig("GAFFER_STARTUP_PATHS", {}, subdirectory="GafferDeadlineUI")

--- a/python/GafferDeadlineUITest/DocumentationTest.py
+++ b/python/GafferDeadlineUITest/DocumentationTest.py
@@ -53,10 +53,14 @@ class DocumentationTest(GafferUITest.TestCase):
     def test(self):
 
         self.maxDiff = None
-        self.assertNodesAreDocumented(GafferDeadline, additionalTerminalPlugTypes = (GafferDispatch.Dispatcher,))
+        self.assertNodesAreDocumented(
+            GafferDeadline,
+            additionalTerminalPlugTypes=(GafferDispatch.Dispatcher,)
+        )
         # Also test GafferDispatch because we add plugs to
         # TaskNodes.
         self.assertNodesAreDocumented(GafferDispatch.TaskNode)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/GafferDeadlineUITest/DocumentationTest.py
+++ b/python/GafferDeadlineUITest/DocumentationTest.py
@@ -42,8 +42,8 @@ import Gaffer
 import GafferTest
 import GafferUI
 import GafferUITest
-
 import GafferDispatch
+
 import GafferDeadline
 import GafferDeadlineUI
 

--- a/python/GafferDeadlineUITest/__init__.py
+++ b/python/GafferDeadlineUITest/__init__.py
@@ -34,7 +34,7 @@
 #
 ##########################################################################
 
-from DocumentationTest import DocumentationTest
+from .DocumentationTest import DocumentationTest
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This upgrades GafferDeadline to Python 3, dropping support for Python 2.
- Rename variables throughout to be camelCase.
- Conform to Pep8 with line length of 100
- Tidy comments