### PR TITLE
Omit no-op tasks from submission

### DIFF
--- a/python/GafferDeadline/DeadlineDispatcher.py
+++ b/python/GafferDeadline/DeadlineDispatcher.py
@@ -118,8 +118,7 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
             context.substitute(self["jobName"].getValue()) or "untitled"
         )
 
-        rootDeadlineJob = GafferDeadlineJob()
-        rootDeadlineJob.setGafferNode(rootBatch.node())
+        rootDeadlineJob = GafferDeadlineJob(rootBatch.node())
         rootDeadlineJob.setAuxFiles([dispatchData["scriptFile"]])
         self.__addGafferDeadlineJob(rootDeadlineJob)
         rootJobs = []
@@ -131,12 +130,6 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
         rootJobs = list(set(rootJobs))
 
         for rootJob in rootJobs:
-            self.__buildDeadlineDependencyWalk(rootJob)
-            # Control jobs with nothing to control should be removed after the dependencies are
-            # set up. This mostly applies to FrameMask nodes where downstream nodes need to see
-            # tasks on the FrameMask to trigger Job-Job dependency mode, but those tasks should
-            # not be submitted to Deadline.
-            self.__removeOrphanTasksWalk(rootJob)
             self.__submitDeadlineJob(rootJob, dispatchData)
 
     def __buildDeadlineJobWalk(self, batch, dispatchData):
@@ -145,8 +138,7 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
 
         deadlineJob = self.__getGafferDeadlineJob(batch.node(), batch.context())
         if not deadlineJob:
-            deadlineJob = GafferDeadlineJob()
-            deadlineJob.setGafferNode(batch.node())
+            deadlineJob = GafferDeadlineJob(batch.node())
             deadlineJob.setContext(batch.context())
             deadlineJob.setAuxFiles([dispatchData["scriptFile"]])
             self.__addGafferDeadlineJob(deadlineJob)
@@ -160,16 +152,6 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
         batch.blindData()["deadlineDispatcher:visited"] = IECore.BoolData(True)
 
         return deadlineJob
-
-    def __buildDeadlineDependencyWalk(self, job):
-        for parentJob in job.getParentJobs():
-            self.__buildDeadlineDependencyWalk(parentJob)
-        job.buildTaskDependencies()
-
-    def __removeOrphanTasksWalk(self, job):
-        for parentJob in job.getParentJobs():
-            self.__removeOrphanTasksWalk(parentJob)
-        job.removeOrphanTasks()
 
     def __getGafferDeadlineJob(self, node, context):
         for j in self._deadlineJobs:
@@ -186,11 +168,10 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
             self.__submitDeadlineJob(parentJob, dispatchData)
 
         gafferNode = deadlineJob.getGafferNode()
-        if (
-            gafferNode is None or
-            len(deadlineJob.getTasks()) == 0 or
-            len(deadlineJob.getTasks()) == 0
-        ):
+
+        # Don't submit command tasks, they pollute the Deadline Monitor and cause
+        # potentially lengthy delays in dequeuing tasks that do nothing.
+        if(GafferDeadlineJob.isControlTask(deadlineJob.getGafferNode())):
             return None
 
         # this job is already submitted if it has an ID
@@ -288,9 +269,9 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
                             for job A runs. If the dependency start and end frame offsets don't
                             match, this has to be handled by a dependency script.
             """
-            depList = deadlineJob.getDependencies()
+            dependencies = deadlineJob.getDependencies().values()
 
-            if len(depList) > 0 and deadlinePlug["dependencyMode"].getValue() != "None":
+            if len(dependencies) > 0 and deadlinePlug["dependencyMode"].getValue() != "None":
                 jobDependent = False
                 frameDependent = False
                 simpleFrameOffset = True
@@ -300,39 +281,29 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
                     frameDependent = True
                 elif deadlinePlug["dependencyMode"].getValue() == "Auto":
                     jobDependent = False
-                    depJobs = [j["dependencyJob"] for j in depList]
-                    depJobs = list(set(depJobs))
-                    for dep in depList:
-                        if (
-                            dep["dependencyTask"].getStartFrame() is None or
-                            dep["dependencyTask"].getEndFrame() is None
-                        ):
-                            jobDependent = True
+                    dependencyJobs = [i.getDeadlineJob() for i in dependencies]
+                    dependencyJobs = list(set(dependencyJobs))
 
                     frameDependent = True
                     simpleFrameOffset = True
-                    if (
-                        len(depList) > 0 and
-                        depList[0]["dependencyTask"].getStartFrame() is not None and
-                        depList[0]["dependencyTask"].getEndFrame() is not None
-                    ):
+                    if (len(dependencies) > 0):
                         deadlineJob._frameDependencyOffsetStart = (
-                            depList[0]["dependencyTask"].getStartFrame() -
-                            depList[0]["dependentTask"].getStartFrame()
+                            list(dependencies)[0].getUpstreamDeadlineTask().getStartFrame() -
+                            list(dependencies)[0].getDeadlineTask().getStartFrame()
                         )
                         deadlineJob._frameDependencyOffsetEnd = (
-                            depList[0]["dependencyTask"].getEndFrame() -
-                            depList[0]["dependentTask"].getEndFrame()
+                            list(dependencies)[0].getUpstreamDeadlineTask().getEndFrame() -
+                            list(dependencies)[0].getDeadlineTask().getEndFrame()
                         )
 
-                        for depTask in depList:
+                        for d in dependencies:
                             newFrameOffsetStart = (
-                                depTask["dependencyTask"].getStartFrame() -
-                                depTask["dependentTask"].getStartFrame()
+                                d.getUpstreamDeadlineTask().getStartFrame() -
+                                d.getDeadlineTask().getStartFrame()
                             )
                             newFrameOffsetEnd = (
-                                depTask["dependencyTask"].getEndFrame() -
-                                depTask["dependentTask"].getEndFrame()
+                                d.getUpstreamDeadlineTask().getEndFrame() -
+                                d.getDeadlineTask().getEndFrame()
                             )
 
                             if (
@@ -344,38 +315,26 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
                         # If we can't just shift the frame start and end, we might still be able to
                         # use frame dependency with tasks of different frame lengths
                         if not simpleFrameOffset:
-                            depJobs = [j["dependencyJob"] for j in depList]
-                            depJobs = list(set(depJobs))
-                            for depJob in depJobs:
-                                depTasks = [
-                                        t["dependencyTask"] for t in depList if (
-                                            t["dependencyJob"] == depJob
-                                        )
+                            for j in dependencyJobs:
+                                dependencyTasks = [
+                                    t.getUpstreamDeadlineTask() for t in dependencies if (
+                                        t.getDeadlineJob() == j
+                                    )
                                 ]
-                                depFrames = []
-                                for t in depTasks:
-                                    if (
-                                        t.getStartFrame() is not None and
-                                        t.getEndFrame() is not None
-                                    ):
-                                        depFrames += range(t.getStartFrame(), t.getEndFrame() + 1)
-                                currentTasks = [
-                                        t["dependentTask"] for t in depList if (
-                                            t["dependencyJob"] == depJob
-                                        )
-                                ]
+                                dependencyFrames = []
+                                for t in dependencyTasks:
+                                    dependencyFrames += range(
+                                        t.getStartFrame(),
+                                        t.getEndFrame() + 1
+                                    )
                                 currentFrames = []
-                                for t in currentTasks:
-                                    if (
-                                        t.getStartFrame() is not None and
-                                        t.getEndFrame() is not None
-                                    ):
-                                        currentFrames += range(
-                                            t.getStartFrame(),
-                                            t.getEndFrame() + 1
-                                        )
+                                for t in deadlineJob.getTasks():
+                                    currentFrames += range(
+                                        t.getStartFrame(),
+                                        t.getEndFrame() + 1
+                                    )
                                 for f in currentFrames:
-                                    if f not in depFrames:
+                                    if f not in dependencyFrames:
                                         frameDependent = False
 
                     else:
@@ -385,7 +344,9 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
                     jobInfo.update(
                         {
                             "JobDependencies": ",".join(
-                                list(set([j["dependencyJob"].getJobID() for j in depList]))
+                                list(set([
+                                    d.getDeadlineJob().getJobID() for d in dependencies
+                                ]))
                             ),
                             "ResumeOnDeletedDependencies": True,
                         }
@@ -402,11 +363,11 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
                     if frameDependent:
                         jobInfo.update({"IsFrameDependent": True})
                         deadlineJob.setDependencyType(
-                            GafferDeadlineJob.DeadlineDependencyType.frameToFrame
+                            GafferDeadlineJob.DeadlineDependencyType.FrameToFrame
                         )
                     else:
                         deadlineJob.setDependencyType(
-                            GafferDeadlineJob.DeadlineDependencyType.jobToJob
+                            GafferDeadlineJob.DeadlineDependencyType.JobToJob
                         )
                 else:
                     jobInfo.update(
@@ -415,18 +376,21 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
                             "IsFrameDependent": True,
                         }
                     )
-                    for i in range(0, len(depList)):
-                        depTask = depList[i]
+                    i = 0
+                    for d in dependencies:
                         jobInfo["ExtraInfoKeyValue{}".format(i)] = "{}:{}={}".format(
-                            int(depTask["dependentTask"].getTaskNumber()),
-                            depTask["dependencyJob"].getJobID(),
-                            depTask["dependencyTask"].getTaskNumber()
+                            int(d.getDeadlineTask().getTaskNumber()),
+                            d.getDeadlineJob().getJobID(),
+                            d.getUpstreamDeadlineTask().getTaskNumber()
                         )
+
+                        i += 1
+
                     deadlineJob.setDependencyType(
-                        GafferDeadlineJob.DeadlineDependencyType.scripted
+                        GafferDeadlineJob.DeadlineDependencyType.Scripted
                     )
             else:
-                deadlineJob.setDependencyType(GafferDeadlineJob.DeadlineDependencyType.none)
+                deadlineJob.setDependencyType(GafferDeadlineJob.DeadlineDependencyType._None)
 
             pluginInfo = {
                 "Script": os.path.split(dispatchData["scriptFile"])[-1],

--- a/python/GafferDeadline/DeadlineDispatcher.py
+++ b/python/GafferDeadline/DeadlineDispatcher.py
@@ -133,6 +133,14 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
             self.__submitDeadlineJob(rootJob, dispatchData)
 
     def __buildDeadlineJobWalk(self, batch, dispatchData):
+        if (
+            GafferDeadlineJob.isControlTask(batch.node()) and
+            batch.node()["dispatcher"]["batchSize"].getValue() > 1
+        ):
+            raise RuntimeError(            
+                "No-Op node {} has a batch size greater than 1.".format(batch.node().getName())
+            )
+
         if batch.blindData().get("deadlineDispatcher:visited"):
             return self.__getGafferDeadlineJob(batch.node(), batch.context())
 

--- a/python/GafferDeadline/GafferDeadlineDependency.py
+++ b/python/GafferDeadline/GafferDeadlineDependency.py
@@ -34,10 +34,21 @@
 #
 ##########################################################################
 
-from .DeadlineDispatcher import DeadlineDispatcher
-from .GafferDeadlineJob import GafferDeadlineJob
-from .GafferDeadlineTask import GafferDeadlineTask
-from .GafferDeadlineDependency import GafferDeadlineDependency
-from .DeadlineTools import *
+class GafferDeadlineDependency(object):
+    """
+    Holds a single dependency for Deadline.
+    """
 
-__import__("IECore").loadConfig("GAFFER_STARTUP_PATHS", {}, subdirectory="GafferDeadline")
+    def __init__(self, deadlineJob, deadlineTask, upstreamDeadlineTask):
+        self._deadlineJob = deadlineJob
+        self._deadlineTask = deadlineTask
+        self._upstreamDeadlineTask = upstreamDeadlineTask
+
+    def getDeadlineJob(self):
+        return self._deadlineJob
+
+    def getDeadlineTask(self):
+        return self._deadlineTask
+
+    def getUpstreamDeadlineTask(self):
+        return self._upstreamDeadlineTask

--- a/python/GafferDeadline/GafferDeadlineTask.py
+++ b/python/GafferDeadline/GafferDeadlineTask.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import IECore
+
 import GafferDispatch
 
 
@@ -51,14 +53,30 @@ class GafferDeadlineTask(object):
         self.setEndFrame(endFrame)
         self.setTaskNumber(taskNumber)
 
-        if self._startFrame is None and self.getGafferBatch() is not None and len(
+        if self.getStartFrame() is None and self.getGafferBatch() is not None and len(
             self.getGafferBatch().frames()
         ) > 0:
-            self.setStartFrame(gafferBatch.frames()[0])
-        if self._endFrame is None and self.getGafferBatch() is not None and len(
+            self.setStartFrame(self.getGafferBatch.frames()[0])
+        if self.getEndFrame() is None and self.getGafferBatch() is not None and len(
             self.getGafferBatch().frames()
         ) > 0:
-            self.setEndFrame(gafferBatch.frames()[len(gafferBatch.frames()) - 1])
+            self.setEndFrame(self.getGafferBatch.frames()[-1])
+
+    def __hash__(self):
+        h = IECore.MurmurHash()
+
+        # hash the batch as Gaffer does in Dispatcher::Batcher::batchHash
+        b = self.getGafferBatch()
+        h.append(hash(b.plug()))
+        for c in b.context().keys():
+            if c != "frame":
+                h.append(b.context()[c])
+
+        h.append(self.getStartFrame() if self.getStartFrame() is not None else 1)
+        h.append(self.getEndFrame() if self.getEndFrame() is not None else 1)
+        h.append(self.getTaskNumber())
+
+        return hash(h)
 
     def setTaskNumber(self, taskNumber):
         assert(type(taskNumber) == int)

--- a/python/GafferDeadlineTest/DeadlineDispatcherTest.py
+++ b/python/GafferDeadlineTest/DeadlineDispatcherTest.py
@@ -38,6 +38,8 @@ import os
 import unittest
 from unittest import mock
 
+import IECore
+
 import Gaffer
 import GafferTest
 import GafferDispatch
@@ -69,6 +71,18 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         dispatcher.dispatch(nodes)
 
         return jobs
+
+    def __debugPrintDependencies(self, dependencies):
+        for d in dependencies.values():
+            print(
+                "{}-{} ->{}:{}-{}".format(
+                    d.getDeadlineTask().getStartFrame(),
+                    d.getDeadlineTask().getEndFrame(),
+                    d.getDeadlineJob().getGafferNode().getName(),
+                    d.getUpstreamDeadlineTask().getStartFrame(),
+                    d.getUpstreamDeadlineTask().getEndFrame()
+                )
+            )
 
     def testPreSpoolSignal(self):
         s = Gaffer.ScriptNode()
@@ -251,49 +265,6 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         self.assertEqual(len(jobs[-1].getParentJobs()[0].getParentJobs()), 1)
         self.assertEqual(len(jobs[-1].getParentJobs()[0].getParentJobs()[0].getParentJobs()), 0)
 
-    def testNoDependencies(self):
-        #   n1
-        #   |
-        #   n2
-
-        s = Gaffer.ScriptNode()
-
-        s["n1"] = GafferDispatchTest.LoggingTaskNode()
-        s["n1"]["frame"] = Gaffer.StringPlug(
-            defaultValue="${frame}",
-            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
-        )
-        s["n1"]["dispatcher"]["batchSize"].setValue(10)
-
-        s["n2"] = GafferDispatchTest.LoggingTaskNode()
-        s["n2"]["frame"] = Gaffer.StringPlug(
-            defaultValue="${frame}", flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic)
-        s["n2"]["dispatcher"]["batchSize"].setValue(13)
-        s["n2"]["preTasks"][0].setInput(s["n1"]["task"])
-
-        dispatcher = self.__dispatcher()
-        dispatcher["framesMode"].setValue(dispatcher.FramesMode.CustomRange)
-        dispatcher["frameRange"].setValue("1-50")
-
-        with mock.patch(
-            "GafferDeadline.DeadlineTools.submitJob",
-            return_value=("testID", "testMessage")
-        ):
-            jobs = self.__job([s["n2"]], dispatcher)
-
-        self.assertEqual(len(jobs), 2)
-        for j in jobs:
-            if j.getJobProperties()["Name"] == "n2":
-                self.assertEqual(len(j.getDependencies()), 8)
-                self.assertEqual(len(j.getTasks()), 4)
-            elif j.getJobProperties()["Name"] == "n1":
-                self.assertEqual(len(j.getDependencies()), 0)
-                self.assertEqual(len(j.getTasks()), 5)
-                self.assertEqual(
-                    j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.none
-                )
-
     def testOverrideNone(self):
         #   n1
         #   |
@@ -334,14 +305,14 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
                 self.assertEqual(len(j.getTasks()), 4)
                 self.assertEqual(
                     j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.none
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType._None
                 )
             elif j.getJobProperties()["Name"] == "n1":
                 self.assertEqual(len(j.getDependencies()), 0)
                 self.assertEqual(len(j.getTasks()), 5)
                 self.assertEqual(
                     j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.none
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType._None
                 )
 
     def testOverrideJob(self):
@@ -384,14 +355,14 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
                 self.assertEqual(len(j.getTasks()), 4)
                 self.assertEqual(
                     j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.jobToJob
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.JobToJob
                 )
             elif j.getJobProperties()["Name"] == "n1":
                 self.assertEqual(len(j.getDependencies()), 0)
                 self.assertEqual(len(j.getTasks()), 5)
                 self.assertEqual(
                     j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.none
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType._None
                 )
 
     def testOverrideFrame(self):
@@ -430,18 +401,19 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         self.assertEqual(len(jobs), 2)
         for j in jobs:
             if j.getJobProperties()["Name"] == "n2":
+                # self.__debugPrintDependencies(j.getDependencies())
                 self.assertEqual(len(j.getDependencies()), 8)
                 self.assertEqual(len(j.getTasks()), 4)
                 self.assertEqual(
                     j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frameToFrame
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.FrameToFrame
                 )
             elif j.getJobProperties()["Name"] == "n1":
                 self.assertEqual(len(j.getDependencies()), 0)
                 self.assertEqual(len(j.getTasks()), 5)
                 self.assertEqual(
                     j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.none
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType._None
                 )
 
     def testOverrideScript(self):
@@ -484,14 +456,14 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
                 self.assertEqual(len(j.getTasks()), 4)
                 self.assertEqual(
                     j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.scripted
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.Scripted
                 )
             elif j.getJobProperties()["Name"] == "n1":
                 self.assertEqual(len(j.getDependencies()), 0)
                 self.assertEqual(len(j.getTasks()), 5)
                 self.assertEqual(
                     j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.none
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType._None
                 )
 
     def testSequence(self):
@@ -499,7 +471,7 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
 
         s["n"] = GafferDispatch.PythonCommand()
         s["n"]["command"] = Gaffer.StringPlug(
-            defaultValue="print(context.getFrame())",
+            defaultValue="for i in frames:\n\tcontext.setFrame(i)\n\tprint(context.getFrame())",
             flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
         )
         s["n"]["sequence"].setValue(True)
@@ -569,7 +541,7 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
                 self.assertEqual(len(j.getTasks()), 5)
                 self.assertEqual(
                     j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.none
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType._None
                 )
 
     def testDependencies(self):
@@ -699,14 +671,8 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         ):
             jobs = self.__job([s["t2"]], dispatcher)
 
-        self.assertEqual(len(jobs), 6)
+        self.assertEqual(len(jobs), 4)
         for j in jobs:
-            if j.getJobProperties()["Name"] == "t2":
-                self.assertEqual(len(j.getDependencies()), 60)
-                self.assertEqual(len(j.getTasks()), 7)
-            if j.getJobProperties()["Name"] == "t1":
-                self.assertEqual(len(j.getDependencies()), 56)
-                self.assertEqual(len(j.getTasks()), 5)
             if j.getJobProperties()["Name"] == "n4":
                 self.assertEqual(len(j.getDependencies()), 0)
                 self.assertEqual(len(j.getTasks()), 50)
@@ -764,9 +730,16 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         s["n4"]["preTasks"][0].setInput(s["n2"]["task"])
 
         s["t1"] = GafferDispatch.TaskList()
-        s["t1"]["dispatcher"]["batchSize"].setValue(10)
+        s["t1"]["dispatcher"]["batchSize"].setValue(1)
         s["t1"]["preTasks"][0].setInput(s["n4"]["task"])
         s["t1"]["preTasks"][1].setInput(s["n3"]["task"])
+
+        s["n5"] = GafferDispatchTest.LoggingTaskNode()
+        s["n5"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
+        s["n5"]["preTasks"][0].setInput(s["t1"]["task"])
 
         dispatcher = self.__dispatcher()
         dispatcher["framesMode"].setValue(dispatcher.FramesMode.CustomRange)
@@ -776,40 +749,44 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
             "GafferDeadline.DeadlineTools.submitJob",
             return_value=("testID", "testMessage")
         ):
-            jobs = self.__job([s["t1"]], dispatcher)
+            jobs = self.__job([s["n5"]], dispatcher)
 
         self.assertEqual(len(jobs), 5)
         for j in jobs:
-            if j.getJobProperties()["Name"] == "n2":
+
+            if j.getJobProperties()["Name"] == "n1":
+                self.assertEqual(len(j.getDependencies()), 0)
+                self.assertEqual(len(j.getTasks()), 50)
+
+            elif j.getJobProperties()["Name"] == "n2":
                 self.assertEqual(len(j.getDependencies()), 50)
                 self.assertEqual(len(j.getTasks()), 4)
                 self.assertEqual(
                     j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frameToFrame
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.FrameToFrame
                 )
-            elif j.getJobProperties()["Name"] == "n1":
-                self.assertEqual(len(j.getDependencies()), 0)
-                self.assertEqual(len(j.getTasks()), 50)
             elif j.getJobProperties()["Name"] == "n3":
                 self.assertEqual(len(j.getDependencies()), 50)
                 self.assertEqual(len(j.getTasks()), 1)
                 self.assertEqual(
                     j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frameToFrame
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.FrameToFrame
                 )
             elif j.getJobProperties()["Name"] == "n4":
                 self.assertEqual(len(j.getDependencies()), 4)
                 self.assertEqual(len(j.getTasks()), 4)
                 self.assertEqual(
                     j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frameToFrame
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.FrameToFrame
                 )
-            elif j.getJobProperties()["Name"] == "t1":
-                self.assertEqual(len(j.getDependencies()), 12)
-                self.assertEqual(len(j.getTasks()), 5)
+
+            elif j.getJobProperties()["Name"] == "n5":
+                # self.__debugPrintDependencies(j.getDependencies())
+                self.assertEqual(len(j.getDependencies()), 100)
+                self.assertEqual(len(j.getTasks()), 50)
                 self.assertEqual(
                     j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frameToFrame
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.FrameToFrame
                 )
 
     def testFrameMask(self):
@@ -850,14 +827,14 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         ):
             jobs = self.__job([s["n2"]], dispatcher)
 
-        self.assertEqual(len(jobs), 3)
+        self.assertEqual(len(jobs), 2)
         for j in jobs:
             if j.getJobProperties()["Name"] == "n2":
-                self.assertEqual(len(j.getDependencies()), 50)
+                self.assertEqual(len(j.getDependencies()), 5)
                 self.assertEqual(len(j.getTasks()), 50)
                 self.assertEqual(
                     j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.jobToJob
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.FrameToFrame
                 )
             elif j.getJobProperties()["Name"] == "n1":
                 self.assertEqual(len(j.getDependencies()), 0)
@@ -933,14 +910,14 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         ):
             jobs = self.__job([s["n2"]], dispatcher)
 
-        self.assertEqual(len(jobs), 3)
+        self.assertEqual(len(jobs), 2)
         for j in jobs:
             if j.getJobProperties()["Name"] == "n2":
                 self.assertEqual(len(j.getDependencies()), 50)
                 self.assertEqual(len(j.getTasks()), 50)
                 self.assertEqual(
                     j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.frameToFrame
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.FrameToFrame
                 )
                 self.assertEqual(j._frameDependencyOffsetStart, 100)
                 self.assertEqual(j._frameDependencyOffsetEnd, 100)
@@ -1019,18 +996,58 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         ):
             jobs = self.__job([s["n2"]], dispatcher)
 
-        self.assertEqual(len(jobs), 3)
+        self.assertEqual(len(jobs), 2)
         for j in jobs:
             if j.getJobProperties()["Name"] == "n2":
                 self.assertEqual(len(j.getDependencies()), 50)
                 self.assertEqual(len(j.getTasks()), 50)
                 self.assertEqual(
                     j.getDependencyType(),
-                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.scripted
+                    GafferDeadline.GafferDeadlineJob.DeadlineDependencyType.Scripted
                 )
             elif j.getJobProperties()["Name"] == "n1":
                 self.assertEqual(len(j.getDependencies()), 0)
                 self.assertEqual(len(j.getTasks()), 50)
+
+    def testControlTaskDependency(self):
+        #   n1 (LoggingTaskNode)
+        #   |
+        #   m1 (FrameMask)
+        #   |
+        #   w1 (Wedge)
+
+        s = Gaffer.ScriptNode()
+
+        s["n1"] = GafferDispatchTest.LoggingTaskNode()
+        s["n1"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${wedge:value}.${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
+
+        s["m1"] = GafferDispatch.FrameMask()
+        s["m1"]["mask"].setValue("1-10")
+        s["m1"]["preTasks"][0].setInput(s["n1"]["task"])
+
+        s["w1"] = GafferDispatch.Wedge()
+        s["w1"]["mode"].setValue(int(GafferDispatch.Wedge.Mode.StringList))
+        s["w1"]["strings"].setValue(IECore.StringVectorData(["a", "b", "c"]))
+        s["w1"]["preTasks"][0].setInput(s["m1"]["task"])
+
+        dispatcher = self.__dispatcher()
+        dispatcher["framesMode"].setValue(dispatcher.FramesMode.CustomRange)
+        dispatcher["frameRange"].setValue("1-50")
+
+        with mock.patch(
+            "GafferDeadline.DeadlineTools.submitJob",
+            return_value=("testID", "testMessage")
+        ):
+            jobs = self.__job([s["w1"]], dispatcher)
+
+        self.assertEqual(len(jobs), 3)  # A LoggingTaskNode per Wedge entry
+        for j in jobs:
+            if j.getJobProperties()["Name"] == "n1":
+                self.assertEqual(len(j.getDependencies()), 0)
+                self.assertEqual(len(j.getTasks()), 10)
 
 
 if __name__ == "__main__":

--- a/python/GafferDeadlineTest/GafferDeadlineJobTest.py
+++ b/python/GafferDeadlineTest/GafferDeadlineJobTest.py
@@ -41,57 +41,63 @@ import Gaffer
 import GafferTest
 import GafferDeadline
 import GafferDispatch
+import GafferDispatchTest
 
 
 class GafferDeadlineJobTest(GafferTest.TestCase):
     def testJobProperties(self):
-        dj = GafferDeadline.GafferDeadlineJob()
+        dj = GafferDeadline.GafferDeadlineJob(GafferDispatchTest.LoggingTaskNode())
         self.assertIn("Plugin", dj.getJobProperties())
         dj.setJobProperties({"testProp": "testVal"})
         self.assertIn("Plugin", dj.getJobProperties())
         self.assertIn("testProp", dj.getJobProperties())
         self.assertEqual(dj.getJobProperties()["testProp"], "testVal")
 
-        dj = GafferDeadline.GafferDeadlineJob(jobProperties={"testProp2": "testVal2"})
+        dj = GafferDeadline.GafferDeadlineJob(
+            GafferDispatchTest.LoggingTaskNode(),
+            jobProperties={"testProp2": "testVal2"}
+        )
         self.assertIn("Plugin", dj.getJobProperties())
         self.assertIn("testProp2", dj.getJobProperties())
         self.assertEqual(dj.getJobProperties()["testProp2"], "testVal2")
 
     def testPluginProperties(self):
-        dj = GafferDeadline.GafferDeadlineJob()
+        dj = GafferDeadline.GafferDeadlineJob(GafferDispatchTest.LoggingTaskNode())
         self.assertEqual(dj.getPluginProperties(), {})
         dj.setPluginProperties({"testProp": "testVal"})
         self.assertIn("testProp", dj.getPluginProperties())
         self.assertEqual(dj.getPluginProperties()["testProp"], "testVal")
 
-        dj = GafferDeadline.GafferDeadlineJob(pluginProperties={"testProp2": "testVal2"})
+        dj = GafferDeadline.GafferDeadlineJob(
+            GafferDispatchTest.LoggingTaskNode(),
+            pluginProperties={"testProp2": "testVal2"}
+        )
         self.assertIn("testProp2", dj.getPluginProperties())
         self.assertEqual(dj.getPluginProperties()["testProp2"], "testVal2")
 
     def testAuxFiles(self):
-        dj = GafferDeadline.GafferDeadlineJob()
+        dj = GafferDeadline.GafferDeadlineJob(GafferDispatchTest.LoggingTaskNode())
         self.assertEqual(dj.getAuxFiles(), [])
         dj.setAuxFiles(["file1", "file2"])
         self.assertEqual(len(dj.getAuxFiles()), 2)
         self.assertIn("file1", dj.getAuxFiles())
 
-        dj = GafferDeadline.GafferDeadlineJob(auxFiles=["file3", "file4"])
+        dj = GafferDeadline.GafferDeadlineJob(
+            GafferDispatchTest.LoggingTaskNode(),
+            auxFiles=["file3", "file4"]
+        )
         self.assertEqual(len(dj.getAuxFiles()), 2)
         self.assertIn("file3", dj.getAuxFiles())
 
     def testGafferNode(self):
         taskNode = GafferDispatch.TaskNode()
-        dj = GafferDeadline.GafferDeadlineJob()
-        dj.setGafferNode(taskNode)
-        self.assertEqual(dj.getGafferNode(), taskNode)
-
-        dj = GafferDeadline.GafferDeadlineJob(gafferNode=taskNode)
+        dj = GafferDeadline.GafferDeadlineJob(taskNode)
         self.assertEqual(dj.getGafferNode(), taskNode)
 
         self.assertRaises(ValueError, dj.setGafferNode, "bad value")
 
     def testAddBatch(self):
-        dj = GafferDeadline.GafferDeadlineJob()
+        dj = GafferDeadline.GafferDeadlineJob(GafferDispatchTest.LoggingTaskNode())
         dj.addBatch(None, [1, 2, 3, 4, 5])
         dj.addBatch(None, [6, 7, 8, 9, 10])
         assert(dj._tasks[0].getStartFrame() == 1)
@@ -99,7 +105,7 @@ class GafferDeadlineJobTest(GafferTest.TestCase):
         assert(dj._tasks[1].getStartFrame() == 6)
         assert(dj._tasks[1].getEndFrame() == 10)
 
-        dj = GafferDeadline.GafferDeadlineJob()
+        dj = GafferDeadline.GafferDeadlineJob(GafferDispatchTest.LoggingTaskNode())
         dj.addBatch(None, [1, 2, 3, 7, 8, 9, 100.0, 101.0, 102.0])
         assert(len(dj._tasks) == 3)
         assert(dj._tasks[0].getTaskNumber() == 0)
@@ -113,16 +119,16 @@ class GafferDeadlineJobTest(GafferTest.TestCase):
         assert(dj._tasks[2].getEndFrame() == 102)
 
     def testContext(self):
-        dj = GafferDeadline.GafferDeadlineJob()
-        self.assertEqual(dj.getContext(), {})
+        dj = GafferDeadline.GafferDeadlineJob(GafferDispatchTest.LoggingTaskNode())
+        self.assertEqual(dj.getContext(), Gaffer.Context())
         dj.setContext({"test": "value"})
         self.assertEqual(dj.getContext(), {"test": "value"})
 
     def testParentJob(self):
-        djc = GafferDeadline.GafferDeadlineJob()
-        djp = GafferDeadline.GafferDeadlineJob()
         taskNode = GafferDispatch.TaskNode()
         taskNode2 = GafferDispatch.TaskNode()
+        djc = GafferDeadline.GafferDeadlineJob(taskNode)
+        djp = GafferDeadline.GafferDeadlineJob(taskNode2)
         djc.addParentJob(djp)
         self.assertIn(djp, djc.getParentJobs())
         djp.setGafferNode(taskNode)


### PR DESCRIPTION
No-ops are task nodes like TaskList and Wedge and don't actually perform any operation. They are no longer submitted, resulting in significantly better submission and Deadline processing performance because there are fewer dependencies that need releasing.