### PR TITLE
Gaffer Plugin : handle unicode characters in Gaffer Scripts

### DIFF
--- a/custom/Gaffer/Gaffer.py
+++ b/custom/Gaffer/Gaffer.py
@@ -121,10 +121,10 @@ class GafferPlugin(DeadlinePlugin):
         tempSceneDirectory = self.CreateTempDirectory("thread" + str(self.GetThreadNumber()))
         tempSceneFilename = Path.Combine(tempSceneDirectory, Path.GetFileName(localScript))
 
-        with open(localScript) as inFile, open(tempSceneFilename, "w") as outFile:
+        with open(localScript, "r") as inFile, open(tempSceneFilename, "w") as outFile:
             for line in inFile:
-                newLine = RepositoryUtils.CheckPathMapping(line)
-                outFile.write(newLine)
+                newLine = RepositoryUtils.CheckPathMapping(line.decode("utf-8"))
+                outFile.write(newLine.encode("utf-8"))
         
         self._gafferScript = tempSceneFilename
 


### PR DESCRIPTION
Unicode characters in Gaffer scripts (for example in a Python command or file name) were causing errors in the Deadline plugin. This PR fixes translating unicode characters during path mapping.