### PR TITLE
Dispatch App : only load UI in "gui" mode

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,7 @@
+# 0.56.0.1
+## Bugs Squished
+- Fixed error "This application failed to start because no Qt platform plugin could be initialized." when running `dispatch` app on a headless system.
+
 # 0.56.0.0
 
 ## New Features

--- a/startup/dispatch/menus.py
+++ b/startup/dispatch/menus.py
@@ -1,1 +1,2 @@
-import GafferDeadlineUI
+if application["gui"].getTypedValue():
+    import GafferDeadlineUI


### PR DESCRIPTION
Fixes error "This application failed to start because no Qt platform plugin could be initialized." when running on a headless system.