### PR TITLE
Plugin : Update Gaffer versions

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,7 +2,7 @@
 
 - Reduced the severity of the check on no-op node batch size from an error to a warning.
 - Removed support for Gaffer versions `1.2.1.0` and `1.2.6.0`
-- Added support for Gaffer versions `1.3.2.0` and `1.2.10.1`
+- Added support for Gaffer versions `1.3.7.0` and `1.2.10.5`
 - Added support for Arnold progress updates in the Deadline plugin.
 
 # 0.57.1.0

--- a/custom/Gaffer/Gaffer.param
+++ b/custom/Gaffer/Gaffer.param
@@ -16,23 +16,23 @@ Index=0
 Default=True
 Description=Not configurable.
 
-[Executable1_2_10_1]
+[Executable1_2_10_5]
 Type=multilinemultifilename
-Category=Gaffer 1.2.10.1 Executables
+Category=Gaffer 1.2.10.5 Executables
 CategoryOrder=0
 CategoryIndex=0
-Label=Gaffer 1.2.10.1 Render Executable
-Default=%HOME%/gaffer_1.2.10.1;~/gaffer_1.2.10.1
-Description=The path to the Gaffer 1.2.10.1 executable (gaffer.cmd on Windows) file used for executing. Enter alternative paths on separate lines.
+Label=Gaffer 1.2.10.5 Render Executable
+Default=%HOME%/gaffer_1.2.10.5;~/gaffer_1.2.10.5
+Description=The path to the Gaffer 1.2.10.5 executable (gaffer.cmd on Windows) file used for executing. Enter alternative paths on separate lines.
 
-[Executable1_3_2_0]
+[Executable1_3_7_0]
 Type=multilinemultifilename
-Category=Gaffer 1.3.2.0 Executables
+Category=Gaffer 1.3.7.0 Executables
 CategoryOrder=0
 CategoryIndex=0
-Label=Gaffer 1.3.2.0 Render Executable
-Default=%HOME%/gaffer_1.3.2.0;~/gaffer_1.3.2.0
-Description=The path to the Gaffer 1.3.2.0 executable (gaffer.cmd on Windows) file used for executing. Enter alternative paths on separate lines.
+Label=Gaffer 1.3.7.0 Render Executable
+Default=%HOME%/gaffer_1.3.7.0;~/gaffer_1.3.7.0
+Description=The path to the Gaffer 1.3.7.0 executable (gaffer.cmd on Windows) file used for executing. Enter alternative paths on separate lines.
 
 [EnablePathMapping]
 Type=boolean


### PR DESCRIPTION
I'm switching here to keep the parameters supporting the latest release and patch versions of Gaffer as of the time of a GafferDeadline release.