### PR TITLE
DocumentationTest : Fix `DeadlineTask` test

### DIFF
--- a/python/GafferDeadlineUITest/DocumentationTest.py
+++ b/python/GafferDeadlineUITest/DocumentationTest.py
@@ -43,6 +43,7 @@ import GafferTest
 import GafferUI
 import GafferUITest
 import GafferDispatch
+import GafferDispatchUI
 
 import GafferDeadline
 import GafferDeadlineUI


### PR DESCRIPTION
I wasn't importing `GafferDispatchUI`, which is what registers the metadata common to all task nodes, causing the test to find them undocumented.