### PR TITLE
GafferDeadlineJob : Make sure `_auxFiles` are strings

### DIFF
--- a/python/GafferDeadline/GafferDeadlineJob.py
+++ b/python/GafferDeadline/GafferDeadlineJob.py
@@ -148,7 +148,7 @@ class GafferDeadlineJob(object):
     def setAuxFiles(self, newAuxFiles):
         assert type(newAuxFiles) == list or type(newAuxFiles) == str
         newAuxFiles = newAuxFiles if type(newAuxFiles) == list else [newAuxFiles]
-        self._auxFiles = newAuxFiles
+        self._auxFiles = [str(f) for f in newAuxFiles]
 
     def getAuxFiles(self):
         return self._auxFiles


### PR DESCRIPTION
This was causing an exception when attempting to hash the values of `_auxFiles` since `pathlib.Path` objects are not supported by MurmurHash.