### PR TITLE
Gaffer 1.4 Compatibility

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,8 +1,9 @@
-# 0.57.x.x
+# 0.58.x.x
 - Add menu entry `/Dispatch/Deadline Dispatch` for compatibility with Gaffer 1.4.
 - Gaffer.param :
   - Drop support for Gaffer versions 1.2.10.5 and 1.3.14.0.
   - Add support for Gaffer versions 1.3.14.0 and 1.4.0.0b4.
+- *Breaking change* : Changed the naming of the temporary files created at submission time to send settings to Deadline. Files are now named by the hash of the task node.
 
 # 0.57.3.0
 - Fixed bug causing an error when dispatching when passing `pathlib.Path` values to `GafferDeadlineJob.setAuxFiles()`.

--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,8 @@
 # 0.57.x.x
 - Add menu entry `/Dispatch/Deadline Dispatch` for compatibility with Gaffer 1.4.
+- Gaffer.param :
+  - Drop support for Gaffer versions 1.2.10.5 and 1.3.14.0.
+  - Add support for Gaffer versions 1.3.14.0 and 1.4.0.0b4.
 
 # 0.57.3.0
 - Fixed bug causing an error when dispatching when passing `pathlib.Path` values to `GafferDeadlineJob.setAuxFiles()`.

--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,5 @@
 # 0.57.x.x
+- Add menu entry `/Dispatch/Deadline Dispatch` for compatibility with Gaffer 1.4.
 
 # 0.57.3.0
 - Fixed bug causing an error when dispatching when passing `pathlib.Path` values to `GafferDeadlineJob.setAuxFiles()`.

--- a/custom/Gaffer/Gaffer.param
+++ b/custom/Gaffer/Gaffer.param
@@ -16,23 +16,23 @@ Index=0
 Default=True
 Description=Not configurable.
 
-[Executable1_2_10_5]
+[Executable1_3_14_0]
 Type=multilinemultifilename
-Category=Gaffer 1.2.10.5 Executables
+Category=Gaffer 1.3.14.0 Executables
 CategoryOrder=0
 CategoryIndex=0
-Label=Gaffer 1.2.10.5 Render Executable
-Default=%HOME%/gaffer_1.2.10.5;~/gaffer_1.2.10.5
-Description=The path to the Gaffer 1.2.10.5 executable (gaffer.cmd on Windows) file used for executing. Enter alternative paths on separate lines.
+Label=Gaffer 1.3.14.0 Render Executable
+Default=%HOME%/gaffer_1.3.14.0;~/gaffer_1.3.14.0
+Description=The path to the Gaffer 1.3.14.0 executable (gaffer.cmd on Windows) file used for executing. Enter alternative paths on separate lines.
 
-[Executable1_3_7_0]
+[Executable1_4_0_0b4]
 Type=multilinemultifilename
-Category=Gaffer 1.3.7.0 Executables
+Category=Gaffer 1.4.0.0b4 Executables
 CategoryOrder=0
 CategoryIndex=0
-Label=Gaffer 1.3.7.0 Render Executable
-Default=%HOME%/gaffer_1.3.7.0;~/gaffer_1.3.7.0
-Description=The path to the Gaffer 1.3.7.0 executable (gaffer.cmd on Windows) file used for executing. Enter alternative paths on separate lines.
+Label=Gaffer 1.4.0.0b4 Render Executable
+Default=%HOME%/gaffer_1.4.0.0b4;~/gaffer_1.4.0.0b4
+Description=The path to the Gaffer 1.4.0.0b4 executable (gaffer.cmd on Windows) file used for executing. Enter alternative paths on separate lines.
 
 [EnablePathMapping]
 Type=boolean

--- a/python/GafferDeadline/DeadlineDispatcher.py
+++ b/python/GafferDeadline/DeadlineDispatcher.py
@@ -465,13 +465,13 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
                 os.path.split(
                     dispatchData["scriptFile"]
                 )[0],
-                gafferNode.relativeName(dispatchData["scriptNode"]) + ".job"
+                str(gafferNode.hash(deadlineJob.getContext())) + ".job"
             )
             pluginFilePath = os.path.join(
                 os.path.split(
                     dispatchData["scriptFile"]
                 )[0],
-                gafferNode.relativeName(dispatchData["scriptNode"]) + ".plugin"
+                str(gafferNode.hash(deadlineJob.getContext())) + ".plugin"
             )
 
             jobId, output = deadlineJob.submitJob(

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -6,4 +6,5 @@ import GafferDeadlineUI
 
 nodeMenu = GafferUI.NodeMenu.acquire(application)
 
+nodeMenu.append("/Dispatch/Deadline Dispatcher", GafferDeadline.DeadlineDispatcher, searchText="DeadlineDispatcher")
 nodeMenu.append("/Deadline/DeadlineTask", GafferDeadline.DeadlineTask, searchText="DeadlineTask")


### PR DESCRIPTION
This adds a new `Deadline Dispatcher` to Gaffer's `Dispatch` menu and updates the stock `Gaffer.param` file for Deadline to include support for Gaffer 1.4.0.0b4.

It also changes how the temporary Deadline files are named, though that is transparent to the user and is only a concern if a user is using those temporary files in some way after dispatch.