### PR TITLE
DeadlineDispatcher : Scope context

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,6 @@
 # 0.58.x.x
+- API : Added `GafferDeadlineJob.environmentVariables()` method.
+- Fixed bug that prevented context variables from being substituted in the `deadlineSettings` and `environmentVariables` plugs.
 
 # 0.58.0.0b2
 - Fixed error `Context has no variable named "frame"` when dispatching with `DeadlineDispatch`.

--- a/python/GafferDeadline/DeadlineDispatcher.py
+++ b/python/GafferDeadline/DeadlineDispatcher.py
@@ -263,14 +263,15 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
 
             environmentVariables = IECore.CompoundData()
 
-            deadlinePlug["environmentVariables"].fillCompoundData(environmentVariables)
-            for name, value in environmentVariables.items():
-                deadlineJob.appendEnvironmentVariable(name, context.substitute(str(value)))
+            with Gaffer.Context(context) as c:
+                deadlinePlug["environmentVariables"].fillCompoundData(environmentVariables)
+                for name, value in environmentVariables.items():
+                    deadlineJob.appendEnvironmentVariable(name, str(value))
 
-            deadlineSettings = IECore.CompoundData()
-            deadlinePlug["deadlineSettings"].fillCompoundData(deadlineSettings)
-            for name, value in deadlineSettings.items():
-                deadlineJob.appendDeadlineSetting(name, context.substitute(str(value)))
+                deadlineSettings = IECore.CompoundData()
+                deadlinePlug["deadlineSettings"].fillCompoundData(deadlineSettings)
+                for name, value in deadlineSettings.items():
+                    deadlineJob.appendDeadlineSetting(name, str(value))
 
             """ Dependencies are stored with a reference to the Deadline job since job IDs weren't
             assigned when the task tree was walked. Now that parent jobs have been submitted and

--- a/python/GafferDeadline/GafferDeadlineJob.py
+++ b/python/GafferDeadline/GafferDeadlineJob.py
@@ -216,6 +216,9 @@ class GafferDeadlineJob(object):
     def appendEnvironmentVariable(self, name, value):
         self._environmentVariables[name] = value
 
+    def getEnvironmentVariables(self):
+        return self._environmentVariables
+
     def appendDeadlineSetting(self, name, value):
         self._deadlineSettings[name] = value
 


### PR DESCRIPTION
When getting the `deadlineSettings` and `environmentVariables` values, we weren't scoping a context first, so values held in context variables were not being substituted.