### PR TITLE
default environment variables

### DIFF
--- a/python/GafferDeadline/DeadlineDispatcher.py
+++ b/python/GafferDeadline/DeadlineDispatcher.py
@@ -268,6 +268,10 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
                 for name, value in environmentVariables.items():
                     deadlineJob.appendEnvironmentVariable(name, str(value))
 
+                if hasattr(GafferDeadline, "DefaultDeadlineEnvVar"):
+                    for name, value in GafferDeadline.DefaultDeadlineEnvVar.items():
+                        deadlineJob.appendEnvironmentVariable(name, str(value)) 
+
                 deadlineSettings = IECore.CompoundData()
                 deadlinePlug["deadlineSettings"].fillCompoundData(deadlineSettings)
                 for name, value in deadlineSettings.items():


### PR DESCRIPTION
Check for DefaultDeadlineEnvVar and add to the environment if it exists.

the idea is that I can add:

import GafferDeadline
GafferDeadline.DefaultDeadlineEnvVar = {"MY_IMPORTANT_ENV": "whatever"}

to a gaffer startup file, and now all my tasks will have the needed environment.

I don't know if this is the best approach but it seems to work. 