### PR TITLE
DeadlineDispatcher : Scope context for all plugs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,6 @@
 # 0.58.x.x
 
+- Fixed bug that prevented context variables from being substituted into GafferDeadline plugs. (#79)
 
 # 0.58.0.0b3
 - API : Added `GafferDeadlineJob.environmentVariables()` method.

--- a/python/GafferDeadline/DeadlineDispatcher.py
+++ b/python/GafferDeadline/DeadlineDispatcher.py
@@ -224,46 +224,45 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
                 else:
                     frameString += ",{}-{}".format(t.getStartFrame(), t.getEndFrame())
 
-            context = deadlineJob.getContext()
-            jobInfo = {
-                        "Name": gafferNode.relativeName(dispatchData["scriptNode"]),
-                        "Frames": frameString,
-                        "ChunkSize": chunkSize,
-                        "Plugin": "Gaffer" if not isinstance(
-                            gafferNode,
-                            GafferDeadline.DeadlineTask
-                        ) else gafferNode["plugin"].getValue(),
-                        "BatchName": dispatchData["deadlineBatch"],
-                        "Comment": context.substitute(deadlinePlug["comment"].getValue()),
-                        "Department": context.substitute(deadlinePlug["department"].getValue()),
-                        "Pool": context.substitute(deadlinePlug["pool"].getValue()),
-                        "SecondaryPool": context.substitute(
-                            deadlinePlug["secondaryPool"].getValue()
-                        ),
-                        "Group": context.substitute(deadlinePlug["group"].getValue()),
-                        "Priority": deadlinePlug["priority"].getValue(),
-                        "TaskTimeoutMinutes": int(deadlinePlug["taskTimeout"].getValue()),
-                        "EnableAutoTimeout": deadlinePlug["enableAutoTimeout"].getValue(),
-                        "ConcurrentTasks": deadlinePlug["concurrentTasks"].getValue(),
-                        "MachineLimit": deadlinePlug["machineLimit"].getValue(),
-                        machineListType: context.substitute(
-                            deadlinePlug["machineList"].getValue()
-                        ),
-                        "LimitGroups": context.substitute(deadlinePlug["limits"].getValue()),
-                        "OnJobComplete": deadlinePlug["onJobComplete"].getValue(),
-                        "InitialStatus": initialStatus,
-                        }
+            with Gaffer.Context(deadlineJob.getContext()) as c:
+                jobInfo = {
+                    "Name": gafferNode.relativeName(dispatchData["scriptNode"]),
+                    "Frames": frameString,
+                    "ChunkSize": chunkSize,
+                    "Plugin": "Gaffer" if not isinstance(
+                        gafferNode,
+                        GafferDeadline.DeadlineTask
+                    ) else gafferNode["plugin"].getValue(),
+                    "BatchName": dispatchData["deadlineBatch"],
+                    "Comment": c.substitute(deadlinePlug["comment"].getValue()),
+                    "Department": c.substitute(deadlinePlug["department"].getValue()),
+                    "Pool": c.substitute(deadlinePlug["pool"].getValue()),
+                    "SecondaryPool": c.substitute(
+                        deadlinePlug["secondaryPool"].getValue()
+                    ),
+                    "Group": c.substitute(deadlinePlug["group"].getValue()),
+                    "Priority": deadlinePlug["priority"].getValue(),
+                    "TaskTimeoutMinutes": int(deadlinePlug["taskTimeout"].getValue()),
+                    "EnableAutoTimeout": deadlinePlug["enableAutoTimeout"].getValue(),
+                    "ConcurrentTasks": deadlinePlug["concurrentTasks"].getValue(),
+                    "MachineLimit": deadlinePlug["machineLimit"].getValue(),
+                    machineListType: c.substitute(
+                        deadlinePlug["machineList"].getValue()
+                    ),
+                    "LimitGroups": c.substitute(deadlinePlug["limits"].getValue()),
+                    "OnJobComplete": deadlinePlug["onJobComplete"].getValue(),
+                    "InitialStatus": initialStatus,
+                }
 
-            auxFiles = deadlineJob.getAuxFiles()   # this will already have substitutions included
-            auxFiles += [context.substitute(f) for f in deadlinePlug["auxFiles"].getValue()]
-            deadlineJob.setAuxFiles(auxFiles)
+                auxFiles = deadlineJob.getAuxFiles()   # this will already have substitutions included
+                auxFiles += [c.substitute(f) for f in deadlinePlug["auxFiles"].getValue()]
+                deadlineJob.setAuxFiles(auxFiles)
 
-            for output in deadlinePlug["outputs"].getValue():
-                deadlineJob.addOutput(output, context)
+                for output in deadlinePlug["outputs"].getValue():
+                    deadlineJob.addOutput(output, c)
 
-            environmentVariables = IECore.CompoundData()
+                environmentVariables = IECore.CompoundData()
 
-            with Gaffer.Context(context) as c:
                 deadlinePlug["environmentVariables"].fillCompoundData(environmentVariables)
                 for name, value in environmentVariables.items():
                     deadlineJob.appendEnvironmentVariable(name, str(value))

--- a/python/GafferDeadlineTest/DeadlineDispatcherTest.py
+++ b/python/GafferDeadlineTest/DeadlineDispatcherTest.py
@@ -1080,6 +1080,7 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         s = Gaffer.ScriptNode()
 
         s["n"] = GafferDispatchTest.LoggingTaskNode()
+        s["n"]["dispatcher"]["deadline"]["comment"].setValue("${wedge:value}")
         s["n"]["dispatcher"]["deadline"]["deadlineSettings"].addChild(
             Gaffer.NameValuePlug(
                 "Name",
@@ -1118,6 +1119,7 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         self.assertEqual(len(jobs), 1)
         self.assertEqual(jobs[0].getJobProperties()["Name"], "I'mAName")
         self.assertEqual(jobs[0].getEnvironmentVariables()["Index"], "0")
+        self.assertEqual(jobs[0].getJobProperties()["Comment"], "I'mAName")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I wasn't scoping the a context when doing `getValue()` calls on plugs, so context variables were not being substituted except for GafferDeadline environment variables and Deadline custom settings. Fixes #79