### PR TITLE
DeadlineDispatcher : Extra settings / env vars

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,7 @@
 # 0.58.x.x
 
 - Fixed bug that prevented context variables from being substituted into GafferDeadline plugs. (#79)
+- Added `extraDeadlineSettings` and `extraEnvironmentVariables` plugs. These can be set by an expression to add arbitrary numbers of Deadline settings and environment variables. Entries in these plugs will take precedence over identically named settings / variables in the `deadlineSettings` and `environmentVariables` plugs.
 
 # 0.58.0.0b3
 - API : Added `GafferDeadlineJob.environmentVariables()` method.

--- a/python/GafferDeadline/DeadlineDispatcher.py
+++ b/python/GafferDeadline/DeadlineDispatcher.py
@@ -264,11 +264,17 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
                 environmentVariables = IECore.CompoundData()
 
                 deadlinePlug["environmentVariables"].fillCompoundData(environmentVariables)
+                extraEnvironmentVariables = deadlinePlug["extraEnvironmentVariables"].getValue()
+                for name, value in extraEnvironmentVariables.items():
+                    environmentVariables[name] = value
                 for name, value in environmentVariables.items():
                     deadlineJob.appendEnvironmentVariable(name, str(value))
 
                 deadlineSettings = IECore.CompoundData()
                 deadlinePlug["deadlineSettings"].fillCompoundData(deadlineSettings)
+                extraDeadlineSettings = deadlinePlug["extraDeadlineSettings"].getValue()
+                for name, value in extraDeadlineSettings.items():
+                    deadlineSettings[name] = value
                 for name, value in deadlineSettings.items():
                     deadlineJob.appendDeadlineSetting(name, str(value))
 
@@ -513,6 +519,8 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
         )
         parentPlug["deadline"]["deadlineSettings"] = Gaffer.CompoundDataPlug()
         parentPlug["deadline"]["environmentVariables"] = Gaffer.CompoundDataPlug()
+        parentPlug["deadline"]["extraDeadlineSettings"] = Gaffer.CompoundObjectPlug()
+        parentPlug["deadline"]["extraEnvironmentVariables"] = Gaffer.CompoundObjectPlug()
 
 
 IECore.registerRunTimeTyped(DeadlineDispatcher, typeName="GafferDeadline::DeadlineDispatcher")

--- a/python/GafferDeadlineUI/DeadlineDispatcherUI.py
+++ b/python/GafferDeadlineUI/DeadlineDispatcherUI.py
@@ -286,6 +286,34 @@ Gaffer.Metadata.registerNode(
             """,
             "layout:section", "Environment Variables",
         ],
+        "dispatcher.deadline.extraDeadlineSettings": [
+            "description",
+            """
+            An additional set of Deadline settings for the job. Arbitrary numbers
+            of settings may be specified within a single `IECore.CompoundObject`,
+            where each key/value pair in the object defines a setting.
+            This is convenient when using an expression to define the settings
+            and the setting count might be dynamic.
+
+            If the same setting is defined by both the settings and the
+            extraSettings plugs, then the value from the extraSettings
+            is taken.
+            """
+        ],
+        "dispatcher.deadline.extraEnvironmentVariables": [
+            "description",
+            """
+            An additional set of environment variables for the job. Arbitrary numbers
+            of variables may be specified within a single `IECore.CompoundObject`,
+            where each key/value pair in the object defines a variable.
+            This is convenient when using an expression to define the variables
+            and the setting count might be dynamic.
+
+            If the same variable is defined by both the variables and the
+            extraEnvironmentVariables plugs, then the value from the
+            extraEnvironmentVariables is taken.
+            """
+        ],
     }
 
 )


### PR DESCRIPTION
This adds two new plugs, `extraDeadlineSettings` and `extraEnvironmentVariables`. These can be set by expressions to add dynamic numbers of settings / environment variables to a job.