### PR TITLE
Use dispatch job name

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,7 @@
 
 - Fixed bug that prevented context variables from being substituted into GafferDeadline plugs. (#79)
 - Added `extraDeadlineSettings` and `extraEnvironmentVariables` plugs. These can be set by an expression to add arbitrary numbers of Deadline settings and environment variables. Entries in these plugs will take precedence over identically named settings / variables in the `deadlineSettings` and `environmentVariables` plugs.
+- *Breaking change* : Changed job names to be `${dispatcher.jobName}.${taskNodeName}`.
 
 # 0.58.0.0b3
 - API : Added `GafferDeadlineJob.environmentVariables()` method.

--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,7 @@
 - Fixed bug that prevented context variables from being substituted into GafferDeadline plugs. (#79)
 - Added `extraDeadlineSettings` and `extraEnvironmentVariables` plugs. These can be set by an expression to add arbitrary numbers of Deadline settings and environment variables. Entries in these plugs will take precedence over identically named settings / variables in the `deadlineSettings` and `environmentVariables` plugs.
 - *Breaking change* : Changed job names to be `${dispatcher.jobName}.${taskNodeName}`.
+- Added `batchName` plug to allow easy customization of the batch name. Previously it would be set to the dispatcher's `jobName` plug value unless overridden in `deadlineSettings`. The default value is the same as dispatchers' `jobName` default value, so unless you change the `batchName` plug value, batches will be named the same as previously.
 
 # 0.58.0.0b3
 - API : Added `GafferDeadlineJob.environmentVariables()` method.

--- a/python/GafferDeadline/DeadlineDispatcher.py
+++ b/python/GafferDeadline/DeadlineDispatcher.py
@@ -114,7 +114,6 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
         dispatchData["scriptNode"].serialiseToFile(dispatchData["scriptFile"])
 
         with Gaffer.Context.current() as c:
-            dispatchData["deadlineBatch"] = self["jobName"].getValue()
             dispatchData["dispatchJobName"] = self["jobName"].getValue()
 
         rootDeadlineJob = GafferDeadline.GafferDeadlineJob(rootBatch.node())
@@ -238,7 +237,7 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
                         gafferNode,
                         GafferDeadline.DeadlineTask
                     ) else gafferNode["plugin"].getValue(),
-                    "BatchName": dispatchData["deadlineBatch"],
+                    "BatchName": deadlinePlug["batchName"].getValue(),
                     "Comment": c.substitute(deadlinePlug["comment"].getValue()),
                     "Department": c.substitute(deadlinePlug["department"].getValue()),
                     "Pool": c.substitute(deadlinePlug["pool"].getValue()),
@@ -490,6 +489,7 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
             return
 
         parentPlug["deadline"] = Gaffer.Plug()
+        parentPlug["deadline"]["batchName"] = Gaffer.StringPlug(defaultValue="${script:name}")
         parentPlug["deadline"]["comment"] = Gaffer.StringPlug()
         parentPlug["deadline"]["department"] = Gaffer.StringPlug()
         parentPlug["deadline"]["pool"] = Gaffer.StringPlug()

--- a/python/GafferDeadline/DeadlineDispatcher.py
+++ b/python/GafferDeadline/DeadlineDispatcher.py
@@ -238,28 +238,24 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
                         GafferDeadline.DeadlineTask
                     ) else gafferNode["plugin"].getValue(),
                     "BatchName": deadlinePlug["batchName"].getValue(),
-                    "Comment": c.substitute(deadlinePlug["comment"].getValue()),
-                    "Department": c.substitute(deadlinePlug["department"].getValue()),
-                    "Pool": c.substitute(deadlinePlug["pool"].getValue()),
-                    "SecondaryPool": c.substitute(
-                        deadlinePlug["secondaryPool"].getValue()
-                    ),
-                    "Group": c.substitute(deadlinePlug["group"].getValue()),
+                    "Comment": deadlinePlug["comment"].getValue(),
+                    "Department": deadlinePlug["department"].getValue(),
+                    "Pool": deadlinePlug["pool"].getValue(),
+                    "SecondaryPool": deadlinePlug["secondaryPool"].getValue(),
+                    "Group": deadlinePlug["group"].getValue(),
                     "Priority": deadlinePlug["priority"].getValue(),
                     "TaskTimeoutMinutes": int(deadlinePlug["taskTimeout"].getValue()),
                     "EnableAutoTimeout": deadlinePlug["enableAutoTimeout"].getValue(),
                     "ConcurrentTasks": deadlinePlug["concurrentTasks"].getValue(),
                     "MachineLimit": deadlinePlug["machineLimit"].getValue(),
-                    machineListType: c.substitute(
-                        deadlinePlug["machineList"].getValue()
-                    ),
-                    "LimitGroups": c.substitute(deadlinePlug["limits"].getValue()),
+                    machineListType: deadlinePlug["machineList"].getValue(),
+                    "LimitGroups": deadlinePlug["limits"].getValue(),
                     "OnJobComplete": deadlinePlug["onJobComplete"].getValue(),
                     "InitialStatus": initialStatus,
                 }
 
                 auxFiles = deadlineJob.getAuxFiles()   # this will already have substitutions included
-                auxFiles += [c.substitute(f) for f in deadlinePlug["auxFiles"].getValue()]
+                auxFiles += [f for f in deadlinePlug["auxFiles"].getValue()]
                 deadlineJob.setAuxFiles(auxFiles)
 
                 for output in deadlinePlug["outputs"].getValue():

--- a/python/GafferDeadline/DeadlineDispatcher.py
+++ b/python/GafferDeadline/DeadlineDispatcher.py
@@ -113,10 +113,9 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
 
         dispatchData["scriptNode"].serialiseToFile(dispatchData["scriptFile"])
 
-        context = Gaffer.Context.current()
-        dispatchData["deadlineBatch"] = (
-            context.substitute(self["jobName"].getValue()) or "untitled"
-        )
+        with Gaffer.Context.current() as c:
+            dispatchData["deadlineBatch"] = self["jobName"].getValue()
+            dispatchData["dispatchJobName"] = self["jobName"].getValue()
 
         rootDeadlineJob = GafferDeadline.GafferDeadlineJob(rootBatch.node())
         rootDeadlineJob.setAuxFiles([dispatchData["scriptFile"]])
@@ -226,7 +225,13 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
 
             with Gaffer.Context(deadlineJob.getContext()) as c:
                 jobInfo = {
-                    "Name": gafferNode.relativeName(dispatchData["scriptNode"]),
+                    "Name": (
+                        "{}{}{}".format(
+                            dispatchData["dispatchJobName"],
+                            "." if dispatchData["dispatchJobName"] else "",
+                            gafferNode.relativeName(dispatchData["scriptNode"]),
+                        )
+                    ),
                     "Frames": frameString,
                     "ChunkSize": chunkSize,
                     "Plugin": "Gaffer" if not isinstance(

--- a/python/GafferDeadlineUI/DeadlineDispatcherUI.py
+++ b/python/GafferDeadlineUI/DeadlineDispatcherUI.py
@@ -70,6 +70,13 @@ Gaffer.Metadata.registerNode(
 
         ],
 
+        "dispatcher.deadline.batchName": [
+            "description",
+            """
+            The name of the Deadline batch for this job.
+            """
+        ],
+
         "dispatcher.deadline.comment": [
             "description",
             """


### PR DESCRIPTION
This changes the naming of jobs to be `${dispatcher.jobName}.${taskNodeName}` instead of just `${taskNodeName}`. It also adds a new `batchName` plug and changes naming of batches. Previously, batches were named by the dispatcher's `jobName`. 