### PR TITLE
DeadlineDispatcher : Use `AtomicCompoundDataPlug`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,7 @@
+# 0.59.0.0
+
+- *Breaking Change* : Changed plug type of `extraDeadlineSettings` and `extraEnvironmentVariables` to `AtomicCompoundDataPlug`. This allows the values to be set by registering `userDefault` metadata and prevents adding non-sensical data such as shaders to these plugs. **It will break existing expressions connected to these plugs.** The broken expression nodes will still exist and can be reconnected by replacing the `__disconnected = IECore.CompoundObjectData( YourCompoundData )` variable assignment with `parent[YourNodeName]["dispatcher"]["deadline"]["extraDeadlineSettings"] = IECore.CompoundData( YourCompoundData )` or  `parent[YourNodeName]["dispatcher"]["deadline"]["extraEnvironmentVariables"] = IECore.CompoundData( YourCompoundData )`.
+
 # 0.58.0.0
 
 - Add menu entry `/Dispatch/Deadline Dispatch` for compatibility with Gaffer 1.4.

--- a/python/GafferDeadline/DeadlineDispatcher.py
+++ b/python/GafferDeadline/DeadlineDispatcher.py
@@ -520,8 +520,8 @@ class DeadlineDispatcher(GafferDispatch.Dispatcher):
         )
         parentPlug["deadline"]["deadlineSettings"] = Gaffer.CompoundDataPlug()
         parentPlug["deadline"]["environmentVariables"] = Gaffer.CompoundDataPlug()
-        parentPlug["deadline"]["extraDeadlineSettings"] = Gaffer.CompoundObjectPlug()
-        parentPlug["deadline"]["extraEnvironmentVariables"] = Gaffer.CompoundObjectPlug()
+        parentPlug["deadline"]["extraDeadlineSettings"] = Gaffer.AtomicCompoundDataPlug()
+        parentPlug["deadline"]["extraEnvironmentVariables"] = Gaffer.AtomicCompoundDataPlug()
 
 
 IECore.registerRunTimeTyped(DeadlineDispatcher, typeName="GafferDeadline::DeadlineDispatcher")

--- a/python/GafferDeadlineTest/DeadlineDispatcherTest.py
+++ b/python/GafferDeadlineTest/DeadlineDispatcherTest.py
@@ -1146,20 +1146,16 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
             )
         )
         s["n"]["dispatcher"]["deadline"]["extraDeadlineSettings"].setValue(
-            IECore.CompoundObject(
-                {
-                    "Name": IECore.StringData("LittleDebbie"),
-                    "MachineName": IECore.StringData("Francis"),
-                }
-            )
+            {
+                "Name": IECore.StringData("LittleDebbie"),
+                "MachineName": IECore.StringData("Francis"),
+            }
         )
         s["n"]["dispatcher"]["deadline"]["extraEnvironmentVariables"].setValue(
-            IECore.CompoundObject(
-                {
-                    "Index": IECore.IntData(0),
-                    "ARNOLD_ROOT": IECore.StringData("/arnoldRoot"),
-                }
-            )
+            {
+                "Index": IECore.IntData(0),
+                "ARNOLD_ROOT": IECore.StringData("/arnoldRoot"),
+            }
         )
 
         s["d"] = GafferDeadline.DeadlineDispatcher()
@@ -1204,11 +1200,9 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
         self.assertEqual(jobs[0].getJobProperties()["Name"], "Harvey.n")
 
         s["n"]["dispatcher"]["deadline"]["extraDeadlineSettings"].setValue(
-            IECore.CompoundObject(
-                {
-                    "Name": IECore.StringData("LittleDebbie"),
-                }
-            )
+            {
+                "Name": IECore.StringData("LittleDebbie"),
+            }
         )
         with mock.patch(
             "GafferDeadline.DeadlineTools.submitJob",


### PR DESCRIPTION
This changes the plug type of `extraDeadlineSettings` and `extraEnvironmentVariables` to `AtomicCompoundDataPlug`. This allows the values to be set by registering `userDefault` metadata and prevents adding non-sensical data such as shaders to these plugs. **It will break existing expressions connected to these plugs.** The broken expression nodes will still exist and can be reconnected by replacing the `__disconnected = IECore.CompoundObjectData( YourCompoundData )` variable assignment with `parent[YourNodeName]["dispatcher"]["deadline"]["extraDeadlineSettings"] = IECore.CompoundData( YourCompoundData )` or  `parent[YourNodeName]["dispatcher"]["deadline"]["extraEnvironmentVariables"] = IECore.CompoundData( YourCompoundData )`.