### PR TITLE
`__getParentBatches()` : Also match on context

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,6 @@
+# 0.59.0.1
+- Fixed bug where a task downstream of a Wedge task would only depend on one of the upstream wedged task / context combinations.
+
 # 0.59.0.0
 
 - *Breaking Change* : Changed plug type of `extraDeadlineSettings` and `extraEnvironmentVariables` to `AtomicCompoundDataPlug`. This allows the values to be set by registering `userDefault` metadata and prevents adding non-sensical data such as shaders to these plugs. **It will break existing expressions connected to these plugs.** The broken expression nodes will still exist and can be reconnected by replacing the `__disconnected = IECore.CompoundObjectData( YourCompoundData )` variable assignment with `parent[YourNodeName]["dispatcher"]["deadline"]["extraDeadlineSettings"] = IECore.CompoundData( YourCompoundData )` or  `parent[YourNodeName]["dispatcher"]["deadline"]["extraEnvironmentVariables"] = IECore.CompoundData( YourCompoundData )`.

--- a/python/GafferDeadline/GafferDeadlineJob.py
+++ b/python/GafferDeadline/GafferDeadlineJob.py
@@ -279,7 +279,7 @@ class GafferDeadlineJob(object):
             if not GafferDeadlineJob.isControlTask(b.node()):
                 job = None
                 for j in effectiveParentJobs:
-                    if j.getGafferNode() == b.node():
+                    if j.getGafferNode() == b.node() and j.getContext() == b.context():
                         job = j
                 if job is not None:
                     batches.append((job, b))

--- a/python/GafferDeadlineTest/DeadlineDispatcherTest.py
+++ b/python/GafferDeadlineTest/DeadlineDispatcherTest.py
@@ -1212,6 +1212,45 @@ class DeadlineDispatcherTest(GafferTest.TestCase):
 
         self.assertEqual(jobs[0].getJobProperties()["Name"], "LittleDebbie")
 
+    def testWedgeTaskDependency(self):
+        #   n1 (LoggingTaskNode)
+        #   |
+        #   w1 (Wedge)
+        #   |
+        #   n2 (LoggingTaskNode)
+
+        s = Gaffer.ScriptNode()
+
+        s["n1"] = GafferDispatchTest.LoggingTaskNode()
+        s["n1"]["frame"] = Gaffer.StringPlug(
+            defaultValue="${wedge:value}.${frame}",
+            flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+        )
+
+        s["w1"] = GafferDispatch.Wedge()
+        s["w1"]["mode"].setValue(int(GafferDispatch.Wedge.Mode.StringList))
+        s["w1"]["strings"].setValue(IECore.StringVectorData(["a", "b", "c"]))
+        s["w1"]["preTasks"][0].setInput(s["n1"]["task"])
+
+        s["n2"] = GafferDispatchTest.LoggingTaskNode()
+        s["n2"]["preTasks"][0].setInput(s["w1"]["task"])
+
+        dispatcher = self.__dispatcher()
+        dispatcher["framesMode"].setValue(dispatcher.FramesMode.CurrentFrame)
+
+        with mock.patch(
+            "GafferDeadline.DeadlineTools.submitJob",
+            return_value=("testID", "testMessage")
+        ):
+            jobs = self.__job([s["n2"]], dispatcher)
+
+        self.assertEqual(len(jobs), 4)
+        for j in jobs:
+            if j.getJobProperties()["Name"] == "n1":
+                self.assertEqual(len(j.getDependencies()), 0)
+            elif j.getJobProperties()["Name"] == "n2":
+                self.assertEqual(len(j.getDependencies()), 3)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
If only matching batches to job / batch combinations based on the node, parent batches would ignore context variations, resulting in incorrect dependency configurations in some cases. One example is a task downstream of a Wedge node that would only depend on one of the context variations of the task being wedged.